### PR TITLE
Enhance presigned URL generation with cache control and versioned cac…

### DIFF
--- a/src/viewport/s3_service.py
+++ b/src/viewport/s3_service.py
@@ -456,24 +456,36 @@ class AsyncS3Client:
         Raises:
             Exception: If URL generation fails
         """
-        # Check cache first
-        cached = get_cached_presigned_url(key)
+        # Check cache first.
+        # Keep a versioned cache key so cache-policy changes can take effect
+        # immediately after deploy without waiting old in-memory entries out.
+        cache_key = f"v2:get:{expires_in}:{key}"
+        cached = get_cached_presigned_url(cache_key)
         if cached:
             logger.debug("Using cached presigned URL for: %s", key)
             return cached
 
         try:
+            # Explicit response cache policy for browser caching.
+            # We align max-age with URL expiry so clients never cache longer
+            # than the signed URL remains valid.
+            cache_max_age = max(0, int(expires_in))
+
             # Create a sync boto3 client for presigned URL generation
             # (presigned URLs are sync operation, no need for async)
             s3_client = self._get_presign_client()
             url = s3_client.generate_presigned_url(
                 "get_object",
-                Params={"Bucket": self.settings.bucket, "Key": key},
+                Params={
+                    "Bucket": self.settings.bucket,
+                    "Key": key,
+                    "ResponseCacheControl": f"private, max-age={cache_max_age}, immutable",
+                },
                 ExpiresIn=expires_in,
             )
             # Cache the presigned URL (with some buffer inside cache function)
             try:
-                cache_presigned_url(key, str(url), expires_in)
+                cache_presigned_url(cache_key, str(url), expires_in)
             except Exception:
                 logger.warning("Failed to cache presigned URL for key %s", key)
 

--- a/tests/test_s3_service.py
+++ b/tests/test_s3_service.py
@@ -524,3 +524,35 @@ class TestAsyncS3ClientClose:
         assert s3_client._session is None
         mock_presign.close.assert_called_once()
         assert s3_client._presign_client is None
+
+
+class TestAsyncS3ClientPresignedGet:
+    """Tests for generate_presigned_url method."""
+
+    def test_generate_presigned_url_sets_response_cache_control(self, s3_client):
+        """Presigned GET should include explicit Cache-Control response override."""
+        mock_presign_client = MagicMock()
+        mock_presign_client.generate_presigned_url.return_value = "https://s3.local/object"
+        s3_client._get_presign_client = MagicMock(return_value=mock_presign_client)
+
+        with patch("viewport.s3_service.get_cached_presigned_url", return_value=None):
+            url = s3_client.generate_presigned_url("gallery/thumb.avif", expires_in=3600)
+
+        assert url == "https://s3.local/object"
+        mock_presign_client.generate_presigned_url.assert_called_once()
+
+        call_kwargs = mock_presign_client.generate_presigned_url.call_args.kwargs
+        assert call_kwargs["ExpiresIn"] == 3600
+        assert call_kwargs["Params"]["Bucket"] == "test-bucket"
+        assert call_kwargs["Params"]["Key"] == "gallery/thumb.avif"
+        assert call_kwargs["Params"]["ResponseCacheControl"] == "private, max-age=3600, immutable"
+
+    def test_generate_presigned_url_uses_cache_before_generating(self, s3_client):
+        """When URL is already cached, boto presign generation should be skipped."""
+        s3_client._get_presign_client = MagicMock()
+
+        with patch("viewport.s3_service.get_cached_presigned_url", return_value="https://cached.local/object"):
+            url = s3_client.generate_presigned_url("gallery/thumb.avif", expires_in=3600)
+
+        assert url == "https://cached.local/object"
+        s3_client._get_presign_client.assert_not_called()


### PR DESCRIPTION
This pull request enhances the `generate_presigned_url` method in the S3 service to improve cache handling and response cache control for presigned URLs. It also adds new unit tests to verify these behaviors. The main changes are grouped as follows:

Improvements to cache policy and cache key versioning:

* The cache key for presigned URLs now includes a version prefix and expiration time, allowing cache-policy changes to take effect immediately after deployment and preventing stale cache entries. (`src/viewport/s3_service.py`)
* The cache lookup and storage now use the new versioned cache key, ensuring consistency and correctness. (`src/viewport/s3_service.py`)

Explicit response cache control for presigned URLs:

* The presigned URL generation now sets the `ResponseCacheControl` parameter with `private, max-age={expires_in}, immutable`, aligning browser cache duration with URL expiry and preventing clients from caching longer than the URL is valid. (`src/viewport/s3_service.py`)

Testing enhancements:

* Added a new test class `TestAsyncS3ClientPresignedGet` with tests to ensure the `ResponseCacheControl` parameter is set correctly and that cached URLs are used without regenerating them. (`tests/test_s3_service.py`)…he keys