### PR TITLE
Enhance gallery functionality with action info and error management

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,7 @@ services:
     restart: always
     command: >
       valkey-server
-      --maxclients 10000
+      --maxclients 1000
       --tcp-backlog 511
       --timeout 0
       --tcp-keepalive 300

--- a/frontend/src/__tests__/pages/GalleryPage.test.tsx
+++ b/frontend/src/__tests__/pages/GalleryPage.test.tsx
@@ -81,6 +81,9 @@ vi.mock('../../services/galleryService', () => ({
   galleryService: {
     getGallery: vi.fn(),
     deleteGallery: vi.fn(),
+    updateGallery: vi.fn(),
+    setCoverPhoto: vi.fn(),
+    clearCoverPhoto: vi.fn(),
   },
 }));
 
@@ -284,6 +287,77 @@ describe('GalleryPage', () => {
       await waitFor(() => {
         expect(screen.queryByAltText('Photo photo1')).not.toBeInTheDocument();
       });
+    });
+
+    it('should treat deleting already-removed photo as successful', async () => {
+      const { photoService } = await import('../../services/photoService');
+      const { ApiError } = await import('../../lib/errorHandling');
+      vi.mocked(photoService.deletePhoto).mockRejectedValue(new ApiError(404, 'Photo not found'));
+
+      render(<GalleryPageWrapper />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { level: 2, name: /Photos/ })).toHaveTextContent(
+          /Photos.*3.*of.*3/,
+        );
+      });
+
+      const photoImages = screen.getAllByAltText(/Photo photo/i);
+      const firstPhoto = photoImages[0];
+      const photoContainer = firstPhoto.closest('.group');
+      expect(photoContainer).toBeInTheDocument();
+
+      const deleteButton = photoContainer!
+        .querySelector('button svg[class*="trash"]')
+        ?.closest('button');
+      expect(deleteButton).toBeInTheDocument();
+
+      await userEvent.hover(photoContainer!);
+      await userEvent.click(deleteButton!);
+      await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+      await waitFor(() => {
+        expect(photoService.deletePhoto).toHaveBeenCalledWith('1', 'photo1');
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByAltText('Photo photo1')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should remove stale photo when setting cover returns 404', async () => {
+      const { galleryService } = await import('../../services/galleryService');
+      const { ApiError } = await import('../../lib/errorHandling');
+      vi.mocked(galleryService.setCoverPhoto).mockRejectedValue(
+        new ApiError(404, 'Photo not found'),
+      );
+
+      render(<GalleryPageWrapper />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { level: 2, name: /Photos/ })).toHaveTextContent(
+          /Photos.*3.*of.*3/,
+        );
+      });
+
+      const photoImages = screen.getAllByAltText(/Photo photo/i);
+      const firstPhoto = photoImages[0];
+      const photoContainer = firstPhoto.closest('.group');
+      expect(photoContainer).toBeInTheDocument();
+
+      await userEvent.hover(photoContainer!);
+      const setCoverButton = screen.getAllByRole('button', { name: /set as cover/i })[0];
+      await userEvent.click(setCoverButton);
+
+      await waitFor(() => {
+        expect(galleryService.setCoverPhoto).toHaveBeenCalledWith('1', 'photo1');
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByAltText('Photo photo1')).not.toBeInTheDocument();
+      });
+
+      expect(screen.getByText('This photo was already deleted.')).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/gallery/GalleryPhotoSection.tsx
+++ b/frontend/src/components/gallery/GalleryPhotoSection.tsx
@@ -29,6 +29,7 @@ interface GalleryPhotoSectionProps {
     photoUrls: PhotoResponse[];
     isLoadingPhotos: boolean;
     uploadError: string | null;
+    actionInfo: string | null;
     error: string | null;
     isSelectionMode: boolean;
   };
@@ -42,6 +43,7 @@ interface GalleryPhotoSectionProps {
   actions: {
     onUploadComplete: (result: PhotoUploadResponse) => void;
     onDismissUploadError: () => void;
+    onDismissActionInfo: () => void;
     onDismissError: () => void;
     onToggleSelectionMode: () => void;
     onTogglePhotoSelection: (photoId: string, isShiftKey: boolean) => void;
@@ -121,6 +123,17 @@ export const GalleryPhotoSection = ({
           <button
             onClick={actions.onDismissUploadError}
             className="ml-auto text-xs font-bold text-accent-foreground bg-danger/80 hover:bg-danger px-3 py-1.5 rounded-lg shadow-sm hover:shadow-md transition-all duration-200 hover:-translate-y-0.5 active:translate-y-0 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-danger focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
+      {state.actionInfo && (
+        <div className="mt-3 text-amber-900 dark:text-amber-200 bg-amber-100/80 dark:bg-amber-900/40 px-4 py-3 rounded-xl text-sm flex items-center gap-3 shadow-xs border border-amber-200/80 dark:border-amber-700/60">
+          {state.actionInfo}
+          <button
+            onClick={actions.onDismissActionInfo}
+            className="ml-auto text-xs font-bold text-amber-900 dark:text-amber-100 bg-amber-200/80 dark:bg-amber-800/70 hover:bg-amber-300 dark:hover:bg-amber-700 px-3 py-1.5 rounded-lg shadow-sm hover:shadow-md transition-all duration-200 hover:-translate-y-0.5 active:translate-y-0 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
           >
             Dismiss
           </button>

--- a/frontend/src/hooks/useGalleryActions.ts
+++ b/frontend/src/hooks/useGalleryActions.ts
@@ -4,6 +4,7 @@ import { photoService, type PhotoResponse } from '../services/photoService';
 import type { PhotoUploadResponse } from '../services/photoService';
 import { shareLinkService, type ShareLink } from '../services/shareLinkService';
 import { useErrorHandler, useConfirmation, useModal } from '../hooks';
+import { handleApiError } from '../lib/errorHandling';
 
 interface UseGalleryActionsProps {
   galleryId: string;
@@ -21,6 +22,7 @@ export const useGalleryActions = ({ galleryId, pagination }: UseGalleryActionsPr
   const [isInitialLoading, setIsInitialLoading] = useState(true);
   const [isLoadingPhotos, setIsLoadingPhotos] = useState(false);
   const [uploadError, setUploadError] = useState('');
+  const [actionInfo, setActionInfo] = useState('');
   const [isCreatingLink, setIsCreatingLink] = useState(false);
   const [shootingDateInput, setShootingDateInput] = useState('');
   const [isSavingShootingDate, setIsSavingShootingDate] = useState(false);
@@ -30,6 +32,15 @@ export const useGalleryActions = ({ galleryId, pagination }: UseGalleryActionsPr
   const renameModal = useModal<{ id: string; filename: string }>();
 
   const { page, pageSize, setTotal } = pagination;
+
+  const isNotFoundError = (error: unknown): boolean => handleApiError(error).statusCode === 404;
+
+  const removePhotoLocally = useCallback((photoId: string) => {
+    setPhotoUrls((prev) => prev.filter((photo) => photo.id !== photoId));
+    setGallery((prev: GalleryDetail | null) =>
+      prev && prev.cover_photo_id === photoId ? { ...prev, cover_photo_id: null } : prev,
+    );
+  }, []);
 
   const fetchGalleryDetails = useCallback(
     async (page: number, isInitial = false) => {
@@ -69,6 +80,7 @@ export const useGalleryActions = ({ galleryId, pagination }: UseGalleryActionsPr
 
     if (result.successful_uploads > 0) {
       try {
+        setActionInfo('');
         setIsLoadingPhotos(true);
         const offset = (page - 1) * pageSize;
         const galleryData = await galleryService.getGallery(galleryId, {
@@ -134,7 +146,13 @@ export const useGalleryActions = ({ galleryId, pagination }: UseGalleryActionsPr
       setGallery((prev: GalleryDetail | null) =>
         prev ? { ...prev, cover_photo_id: photoId } : null,
       );
+      setActionInfo('');
     } catch (err) {
+      if (isNotFoundError(err)) {
+        removePhotoLocally(photoId);
+        setActionInfo('This photo was already deleted.');
+        return;
+      }
       handleError(err);
     }
   };
@@ -205,8 +223,14 @@ export const useGalleryActions = ({ galleryId, pagination }: UseGalleryActionsPr
       onConfirm: async () => {
         try {
           await photoService.deletePhoto(galleryId, photoId);
-          setPhotoUrls((prev) => prev.filter((photo) => photo.id !== photoId));
+          removePhotoLocally(photoId);
+          setActionInfo('');
         } catch (err) {
+          if (isNotFoundError(err)) {
+            removePhotoLocally(photoId);
+            setActionInfo('This photo was already deleted.');
+            return;
+          }
           handleError(err);
           throw err;
         }
@@ -221,15 +245,55 @@ export const useGalleryActions = ({ galleryId, pagination }: UseGalleryActionsPr
       isDangerous: true,
       confirmText: 'Delete',
       onConfirm: async () => {
-        try {
-          await Promise.all(
-            Array.from(selectedIds).map((photoId) => photoService.deletePhoto(galleryId, photoId)),
+        const deletedOrMissingIds: string[] = [];
+        let notFoundCount = 0;
+        let firstUnexpectedError: unknown = null;
+
+        await Promise.all(
+          Array.from(selectedIds).map(async (photoId) => {
+            try {
+              await photoService.deletePhoto(galleryId, photoId);
+              deletedOrMissingIds.push(photoId);
+            } catch (err) {
+              if (isNotFoundError(err)) {
+                deletedOrMissingIds.push(photoId);
+                notFoundCount += 1;
+                return;
+              }
+
+              if (!firstUnexpectedError) {
+                firstUnexpectedError = err;
+              }
+            }
+          }),
+        );
+
+        if (deletedOrMissingIds.length > 0) {
+          const deletedOrMissingSet = new Set(deletedOrMissingIds);
+          setPhotoUrls((prev) => prev.filter((photo) => !deletedOrMissingSet.has(photo.id)));
+          setGallery((prev: GalleryDetail | null) =>
+            prev && prev.cover_photo_id && deletedOrMissingSet.has(prev.cover_photo_id)
+              ? { ...prev, cover_photo_id: null }
+              : prev,
           );
-          setPhotoUrls((prev) => prev.filter((photo) => !selectedIds.has(photo.id)));
+        }
+
+        if (firstUnexpectedError) {
+          handleError(firstUnexpectedError);
+          throw firstUnexpectedError;
+        }
+
+        if (deletedOrMissingIds.length > 0) {
+          if (notFoundCount > 0) {
+            setActionInfo(
+              notFoundCount === 1
+                ? '1 photo was already deleted.'
+                : `${notFoundCount} photos were already deleted.`,
+            );
+          } else {
+            setActionInfo('');
+          }
           clearSelection();
-        } catch (err) {
-          handleError(err);
-          throw err;
         }
       },
     });
@@ -243,6 +307,8 @@ export const useGalleryActions = ({ galleryId, pagination }: UseGalleryActionsPr
     isLoadingPhotos,
     uploadError,
     setUploadError,
+    actionInfo,
+    setActionInfo,
     isCreatingLink,
     shootingDateInput,
     setShootingDateInput,

--- a/frontend/src/pages/GalleryPage.tsx
+++ b/frontend/src/pages/GalleryPage.tsx
@@ -35,6 +35,8 @@ export const GalleryPage = () => {
     isLoadingPhotos,
     uploadError,
     setUploadError,
+    actionInfo,
+    setActionInfo,
     isCreatingLink,
     shootingDateInput,
     setShootingDateInput,
@@ -190,6 +192,7 @@ export const GalleryPage = () => {
             photoUrls,
             isLoadingPhotos,
             uploadError,
+            actionInfo,
             error,
             isSelectionMode,
           }}
@@ -203,6 +206,7 @@ export const GalleryPage = () => {
           actions={{
             onUploadComplete: handleUploadComplete,
             onDismissUploadError: () => setUploadError(''),
+            onDismissActionInfo: () => setActionInfo(''),
             onDismissError: clearError,
             onToggleSelectionMode: () => {
               if (isSelectionMode) {


### PR DESCRIPTION
This pull request improves the user experience and error handling for photo deletion and cover photo actions in the gallery feature. It ensures that attempts to delete or set a cover for photos that have already been removed are handled gracefully, with clear feedback to the user. The changes also add new UI elements to display informative messages and allow dismissing them.

**Error Handling and User Feedback Improvements**
* Added logic to treat deleting already-removed photos and setting a cover photo for a missing photo as successful actions, removing stale photos from the UI and displaying an info message when a 404 error occurs. [[1]](diffhunk://#diff-dafdfa4c44ef37a9722a668b442e1bff47de853100db47e355699b1b6c792138R149-R155) [[2]](diffhunk://#diff-dafdfa4c44ef37a9722a668b442e1bff47de853100db47e355699b1b6c792138L208-R233) [[3]](diffhunk://#diff-dafdfa4c44ef37a9722a668b442e1bff47de853100db47e355699b1b6c792138L224-L232) [[4]](diffhunk://#diff-26904174406e3102a894fccb689c009963c0b1ff1f1c4176dcd90ed75c20086dR291-R361)
* Introduced the `actionInfo` state to hold user-facing info messages and provided a dismiss mechanism for these messages in the UI. [[1]](diffhunk://#diff-dafdfa4c44ef37a9722a668b442e1bff47de853100db47e355699b1b6c792138R25) [[2]](diffhunk://#diff-df12fd8769341e9547fb32a4b91658da041555d30d0ebe2509442a7305379adeR32) [[3]](diffhunk://#diff-df12fd8769341e9547fb32a4b91658da041555d30d0ebe2509442a7305379adeR46) [[4]](diffhunk://#diff-df12fd8769341e9547fb32a4b91658da041555d30d0ebe2509442a7305379adeR131-R141) [[5]](diffhunk://#diff-dafdfa4c44ef37a9722a668b442e1bff47de853100db47e355699b1b6c792138R310-R311) [[6]](diffhunk://#diff-1ad38113396286824031d57a90051bb009baaa38e32d54d10cec31eaff15e40fR38-R39) [[7]](diffhunk://#diff-1ad38113396286824031d57a90051bb009baaa38e32d54d10cec31eaff15e40fR195) [[8]](diffhunk://#diff-1ad38113396286824031d57a90051bb009baaa38e32d54d10cec31eaff15e40fR209)

**Test Coverage Enhancements**
* Added tests to verify the new error handling behavior for deleting already-removed photos and setting a cover photo for a missing photo.
* Updated mocks in tests to include new gallery service methods (`updateGallery`, `setCoverPhoto`, `clearCoverPhoto`).

**Minor Configuration Change**
* Reduced the `valkey-server` `--maxclients` setting in `docker-compose.yml` from 10000 to 1000 for resource optimization.