### PR TITLE
Enforce unique photo filenames within a gallery

### DIFF
--- a/docs/backend/models.md
+++ b/docs/backend/models.md
@@ -192,6 +192,9 @@ class Photo(Base):
 **Indexes:**
 - `gallery_id` - for fast photo lookups by gallery
 
+**Constraints:**
+- `gallery_id + object_key` must be unique, so photo filenames are unique within a gallery scope
+
 **Storage:**
 - Original images stored in S3 with object_key
 - Thumbnails stored in S3 with thumbnail_object_key

--- a/src/viewport/alembic/versions/2026_02_28_b1c2d3e4f5a6_add_unique_photo_name_per_gallery.py
+++ b/src/viewport/alembic/versions/2026_02_28_b1c2d3e4f5a6_add_unique_photo_name_per_gallery.py
@@ -1,0 +1,26 @@
+"""add_unique_photo_name_per_gallery
+
+Revision ID: b1c2d3e4f5a6
+Revises: 0d8b5cd635e9
+Create Date: 2026-02-28 00:00:00.000000
+
+"""
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b1c2d3e4f5a6"
+down_revision: str | Sequence[str] | None = "0d8b5cd635e9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_unique_constraint("uq_photos_gallery_id_object_key", "photos", ["gallery_id", "object_key"])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_constraint("uq_photos_gallery_id_object_key", "photos", type_="unique")

--- a/src/viewport/api/photo.py
+++ b/src/viewport/api/photo.py
@@ -1,10 +1,10 @@
 import logging
 import re
-import time
 from uuid import UUID, uuid4
 
 from botocore.exceptions import ClientError
 from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from viewport.auth_utils import get_current_user
@@ -28,6 +28,8 @@ from viewport.schemas.photo import (
 logger = logging.getLogger(__name__)
 
 MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
+
+DUPLICATE_PHOTO_NAME_ERROR = "A photo with this name already exists in this gallery."
 
 # Pre-computed content type mapping for faster lookups
 CONTENT_TYPE_MAP = {
@@ -151,6 +153,7 @@ def batch_presigned_uploads(
     items: list[BatchPresignedUploadItem] = []
     photos_payload: list[dict] = []
     failed_presign_bytes = 0
+    seen_object_keys: set[str] = set()
 
     # 2. Generate Photo records and presigned URLs
     for file_request in request.files:
@@ -165,10 +168,31 @@ def batch_presigned_uploads(
             )
             continue
 
-        timestamp = int(time.time() * 1000)
         safe_filename = sanitize_filename(file_request.filename)
-        object_key = f"{gallery_id}/{timestamp}_{safe_filename}"
+        object_key = f"{gallery_id}/{safe_filename}"
         photo_id = uuid4()
+
+        if object_key in seen_object_keys:
+            items.append(
+                BatchPresignedUploadItem(
+                    filename=file_request.filename,
+                    file_size=file_request.file_size,
+                    success=False,
+                    error=DUPLICATE_PHOTO_NAME_ERROR,
+                )
+            )
+            continue
+
+        if repo.photo_object_key_exists(gallery_id, object_key):
+            items.append(
+                BatchPresignedUploadItem(
+                    filename=file_request.filename,
+                    file_size=file_request.file_size,
+                    success=False,
+                    error=DUPLICATE_PHOTO_NAME_ERROR,
+                )
+            )
+            continue
 
         # Generate presigned PUT signed with exact size and tagging requirements
         try:
@@ -189,6 +213,8 @@ def batch_presigned_uploads(
                 )
             )
             continue
+
+        seen_object_keys.add(object_key)
 
         photos_payload.append(
             {
@@ -223,6 +249,12 @@ def batch_presigned_uploads(
     if photos_payload:
         try:
             repo.create_photos_batch(photos_payload)
+        except IntegrityError as exc:
+            reserved_for_created = bytes_to_reserve - failed_presign_bytes
+            if reserved_for_created > 0:
+                user_repo.release_reserved_storage(current_user.id, reserved_for_created)
+            repo.db.rollback()
+            raise HTTPException(status_code=400, detail=DUPLICATE_PHOTO_NAME_ERROR) from exc
         except Exception:
             reserved_for_created = bytes_to_reserve - failed_presign_bytes
             if reserved_for_created > 0:
@@ -392,8 +424,13 @@ async def rename_photo(
     if not gallery:
         raise HTTPException(status_code=404, detail="Gallery not found")
 
+    sanitized_filename = sanitize_filename(request.filename)
+    new_object_key = f"{gallery_id}/{sanitized_filename}"
+    if repo.photo_object_key_exists(gallery_id, new_object_key, exclude_photo_id=photo_id):
+        raise HTTPException(status_code=400, detail=DUPLICATE_PHOTO_NAME_ERROR)
+
     # Then, verify photo belongs to that gallery and rename it
-    photo = await repo.rename_photo_async(photo_id, gallery_id, current_user.id, request.filename, s3_client)
+    photo = await repo.rename_photo_async(photo_id, gallery_id, current_user.id, sanitized_filename, s3_client)
     if not photo:
         raise HTTPException(status_code=404, detail="Photo not found")
 

--- a/src/viewport/models/gallery.py
+++ b/src/viewport/models/gallery.py
@@ -3,7 +3,7 @@ from datetime import UTC, date, datetime
 from enum import IntEnum
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Boolean, Date, DateTime, ForeignKey, Integer, SmallInteger, String
+from sqlalchemy import Boolean, Date, DateTime, ForeignKey, Integer, SmallInteger, String, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -64,6 +64,7 @@ class Gallery(Base):
 
 class Photo(Base):
     __tablename__ = "photos"
+    __table_args__ = (UniqueConstraint("gallery_id", "object_key", name="uq_photos_gallery_id_object_key"),)
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     gallery_id: Mapped[uuid.UUID] = mapped_column(

--- a/src/viewport/repositories/gallery_repository.py
+++ b/src/viewport/repositories/gallery_repository.py
@@ -3,7 +3,7 @@ import time
 import uuid
 from datetime import UTC, date, datetime
 
-from sqlalchemy import func, insert, select, update
+from sqlalchemy import exists, func, insert, select, update
 from sqlalchemy.orm import selectinload
 
 from viewport.models.gallery import Gallery, Photo, PhotoUploadStatus
@@ -231,6 +231,13 @@ class GalleryRepository(BaseRepository):
         if commit:
             self.db.commit()
 
+    def photo_object_key_exists(self, gallery_id: uuid.UUID, object_key: str, exclude_photo_id: uuid.UUID | None = None) -> bool:
+        conditions = [Photo.gallery_id == gallery_id, Photo.object_key == object_key]
+        if exclude_photo_id is not None:
+            conditions.append(Photo.id != exclude_photo_id)
+        stmt = select(exists().where(*conditions))
+        return bool(self.db.execute(stmt).scalar())
+
     def create_photo(self, gallery_id: uuid.UUID, object_key: str, thumbnail_object_key: str, file_size: int, width: int | None = None, height: int | None = None) -> Photo:
         photo = Photo(gallery_id=gallery_id, object_key=object_key, thumbnail_object_key=thumbnail_object_key, file_size=file_size, width=width, height=height)
         self.db.add(photo)
@@ -351,6 +358,9 @@ class GalleryRepository(BaseRepository):
             # Fallback if object_key doesn't have the expected format
             new_object_key = f"{gallery_id}/{new_filename}"
 
+        if self.photo_object_key_exists(gallery_id, new_object_key, exclude_photo_id=photo_id):
+            return None
+
         # Clear cached presigned URL for old object key
         clear_presigned_url_cache(photo.object_key)
 
@@ -380,6 +390,9 @@ class GalleryRepository(BaseRepository):
         else:
             # Fallback if object_key doesn't have the expected format
             new_object_key = f"{gallery_id}/{new_filename}"
+
+        if self.photo_object_key_exists(gallery_id, new_object_key, exclude_photo_id=photo_id):
+            return None
 
         # Rename the file in S3 first
         try:

--- a/tests/test_photo_api.py
+++ b/tests/test_photo_api.py
@@ -178,6 +178,36 @@ class TestPhotoAPI:
         assert item["presigned_data"]["headers"]["Content-Type"] == "image/png"
         assert item["presigned_data"]["url"].startswith("http")
 
+
+    def test_batch_presigned_uploads_rejects_duplicate_filename_in_gallery(self, authenticated_client: TestClient, gallery_id_fixture: str):
+        """Uploading with an existing filename in the same gallery is rejected."""
+        upload_photo_via_presigned(authenticated_client, gallery_id_fixture, b"seed", "duplicate.jpg")
+
+        payload = {"files": [{"filename": "duplicate.jpg", "file_size": 128, "content_type": "image/jpeg"}]}
+        response = authenticated_client.post(f"/galleries/{gallery_id_fixture}/photos/batch-presigned", json=payload)
+
+        assert response.status_code == 200
+        item = response.json()["items"][0]
+        assert not item["success"]
+        assert item["error"] == "A photo with this name already exists in this gallery."
+
+    def test_batch_presigned_uploads_rejects_duplicate_filename_in_request(self, authenticated_client: TestClient, gallery_id_fixture: str):
+        """Uploading duplicate filenames in one batch request rejects duplicates."""
+        payload = {
+            "files": [
+                {"filename": "same.jpg", "file_size": 64, "content_type": "image/jpeg"},
+                {"filename": "same.jpg", "file_size": 64, "content_type": "image/jpeg"},
+            ]
+        }
+
+        response = authenticated_client.post(f"/galleries/{gallery_id_fixture}/photos/batch-presigned", json=payload)
+
+        assert response.status_code == 200
+        items = response.json()["items"]
+        assert items[0]["success"] is True
+        assert items[1]["success"] is False
+        assert items[1]["error"] == "A photo with this name already exists in this gallery."
+
     def test_batch_presigned_uploads_size_limit(self, authenticated_client: TestClient, gallery_id_fixture: str):
         """Files that exceed MAX_FILE_SIZE are rejected."""
         payload = {"files": [{"filename": "huge.jpg", "file_size": MAX_FILE_SIZE + 1, "content_type": "image/jpeg"}]}
@@ -231,6 +261,21 @@ class TestPhotoAPI:
 
         second = authenticated_client.delete(f"/galleries/{gallery_id_fixture}/photos/{photo_id}")
         assert second.status_code == 404
+
+
+    def test_rename_photo_duplicate_filename_in_gallery(self, authenticated_client: TestClient, gallery_id_fixture: str):
+        """Renaming to an existing filename in the same gallery returns 400."""
+        first_photo_id = upload_photo_via_presigned(authenticated_client, gallery_id_fixture, b"first", "first.jpg")
+        second_photo_id = upload_photo_via_presigned(authenticated_client, gallery_id_fixture, b"second", "second.jpg")
+
+        response = authenticated_client.patch(
+            f"/galleries/{gallery_id_fixture}/photos/{second_photo_id}/rename",
+            json={"filename": "first.jpg"},
+        )
+
+        assert first_photo_id != second_photo_id
+        assert response.status_code == 400
+        assert response.json()["detail"] == "A photo with this name already exists in this gallery."
 
     def test_rename_photo_success(self, authenticated_client: TestClient, gallery_id_fixture: str):
         """Renaming a photo updates the filename."""


### PR DESCRIPTION
### Motivation
- Prevent duplicate photo display names within the same gallery which currently cause frontend rendering collisions and ZIP archive overwrites.
- Ensure uniqueness is enforced both at the API validation layer and the database level to avoid race conditions.

### Description
- Added a DB-level unique constraint on `photos (gallery_id, object_key)` and included an Alembic migration `2026_02_28_b1c2d3e4f5a6_add_unique_photo_name_per_gallery.py` to create/drop the constraint.
- Added `photo_object_key_exists(...)` repository helper with an `exclude_photo_id` option and used it to guard renames and uploads at the repository layer.
- Updated batch upload (`POST /galleries/{gallery_id}/photos/batch-presigned`) to sanitize filenames, reject duplicates already present in the gallery, reject duplicates within the same batch request, and map DB `IntegrityError` to a `400` with the message `"A photo with this name already exists in this gallery."`.
- Updated rename endpoint (`PATCH /galleries/{gallery_id}/photos/{photo_id}/rename`) to sanitize the requested filename and return `400` with the same error message when a gallery-scoped conflict is detected before attempting the S3/database rename.
- Added tests covering duplicate upload and duplicate rename scenarios and updated backend model documentation to mention the per-gallery uniqueness constraint.

### Testing
- Ran code style checks: `uv run ruff check ...` which passed after automatic fixes.
- Ran targeted pytest suite for the new API tests locally but the run failed in this environment because `testcontainers` requires a Docker daemon that is unavailable here; the failures are environmental (docker/testcontainers connection errors) and not related to the new logic.
- Created and included Alembic migration file `2026_02_28_b1c2d3e4f5a6_add_unique_photo_name_per_gallery.py` to apply the DB constraint in deployments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a32f0591408332a284c1ec149113de)