### PR TITLE
Enforce unique photo filenames per gallery (upload & rename)

### DIFF
--- a/src/viewport/alembic/versions/2026_02_28_b1c2d3e4f5a6_add_unique_photo_name_per_gallery.py
+++ b/src/viewport/alembic/versions/2026_02_28_b1c2d3e4f5a6_add_unique_photo_name_per_gallery.py
@@ -1,0 +1,22 @@
+"""add unique photo name per gallery
+
+Revision ID: b1c2d3e4f5a6
+Revises: 0d8b5cd635e9
+Create Date: 2026-02-28 00:00:00.000000
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b1c2d3e4f5a6"
+down_revision = "0d8b5cd635e9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_unique_constraint("uq_photos_gallery_id_object_key", "photos", ["gallery_id", "object_key"])
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_photos_gallery_id_object_key", "photos", type_="unique")

--- a/src/viewport/api/photo.py
+++ b/src/viewport/api/photo.py
@@ -1,10 +1,10 @@
 import logging
 import re
-import time
 from uuid import UUID, uuid4
 
 from botocore.exceptions import ClientError
 from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from viewport.auth_utils import get_current_user
@@ -28,6 +28,7 @@ from viewport.schemas.photo import (
 logger = logging.getLogger(__name__)
 
 MAX_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
+DUPLICATE_PHOTO_NAME_ERROR = "A photo with this name already exists in this gallery."
 
 # Pre-computed content type mapping for faster lookups
 CONTENT_TYPE_MAP = {
@@ -152,6 +153,11 @@ def batch_presigned_uploads(
     photos_payload: list[dict] = []
     failed_presign_bytes = 0
 
+    existing_filenames = {
+        photo.object_key.split("/", 1)[1] if "/" in photo.object_key else photo.object_key for photo in repo.get_photos_by_gallery_id(gallery_id)
+    }
+    requested_filenames: set[str] = set()
+
     # 2. Generate Photo records and presigned URLs
     for file_request in request.files:
         if file_request.file_size > MAX_FILE_SIZE:
@@ -165,9 +171,21 @@ def batch_presigned_uploads(
             )
             continue
 
-        timestamp = int(time.time() * 1000)
         safe_filename = sanitize_filename(file_request.filename)
-        object_key = f"{gallery_id}/{timestamp}_{safe_filename}"
+        if safe_filename in existing_filenames or safe_filename in requested_filenames:
+            failed_presign_bytes += file_request.file_size
+            items.append(
+                BatchPresignedUploadItem(
+                    filename=file_request.filename,
+                    file_size=file_request.file_size,
+                    success=False,
+                    error=DUPLICATE_PHOTO_NAME_ERROR,
+                )
+            )
+            continue
+
+        requested_filenames.add(safe_filename)
+        object_key = f"{gallery_id}/{safe_filename}"
         photo_id = uuid4()
 
         # Generate presigned PUT signed with exact size and tagging requirements
@@ -223,6 +241,11 @@ def batch_presigned_uploads(
     if photos_payload:
         try:
             repo.create_photos_batch(photos_payload)
+        except IntegrityError as exc:
+            reserved_for_created = bytes_to_reserve - failed_presign_bytes
+            if reserved_for_created > 0:
+                user_repo.release_reserved_storage(current_user.id, reserved_for_created)
+            raise HTTPException(status_code=400, detail=DUPLICATE_PHOTO_NAME_ERROR) from exc
         except Exception:
             reserved_for_created = bytes_to_reserve - failed_presign_bytes
             if reserved_for_created > 0:
@@ -392,8 +415,16 @@ async def rename_photo(
     if not gallery:
         raise HTTPException(status_code=404, detail="Gallery not found")
 
+    new_filename = sanitize_filename(request.filename)
+    if repo.photo_name_exists_in_gallery(gallery_id, new_filename, exclude_photo_id=photo_id):
+        raise HTTPException(status_code=400, detail=DUPLICATE_PHOTO_NAME_ERROR)
+
     # Then, verify photo belongs to that gallery and rename it
-    photo = await repo.rename_photo_async(photo_id, gallery_id, current_user.id, request.filename, s3_client)
+    try:
+        photo = await repo.rename_photo_async(photo_id, gallery_id, current_user.id, new_filename, s3_client)
+    except IntegrityError as exc:
+        raise HTTPException(status_code=400, detail=DUPLICATE_PHOTO_NAME_ERROR) from exc
+
     if not photo:
         raise HTTPException(status_code=404, detail="Photo not found")
 

--- a/src/viewport/models/gallery.py
+++ b/src/viewport/models/gallery.py
@@ -3,7 +3,7 @@ from datetime import UTC, date, datetime
 from enum import IntEnum
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Boolean, Date, DateTime, ForeignKey, Integer, SmallInteger, String
+from sqlalchemy import Boolean, Date, DateTime, ForeignKey, Integer, SmallInteger, String, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -64,6 +64,9 @@ class Gallery(Base):
 
 class Photo(Base):
     __tablename__ = "photos"
+    __table_args__ = (
+        UniqueConstraint("gallery_id", "object_key", name="uq_photos_gallery_id_object_key"),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     gallery_id: Mapped[uuid.UUID] = mapped_column(

--- a/src/viewport/repositories/gallery_repository.py
+++ b/src/viewport/repositories/gallery_repository.py
@@ -231,6 +231,14 @@ class GalleryRepository(BaseRepository):
         if commit:
             self.db.commit()
 
+    def photo_name_exists_in_gallery(self, gallery_id: uuid.UUID, filename: str, exclude_photo_id: uuid.UUID | None = None) -> bool:
+        """Check whether a filename already exists within a gallery."""
+        object_key = f"{gallery_id}/{filename}"
+        stmt = select(Photo.id).where(Photo.gallery_id == gallery_id, Photo.object_key == object_key)
+        if exclude_photo_id is not None:
+            stmt = stmt.where(Photo.id != exclude_photo_id)
+        return self.db.execute(stmt).scalar_one_or_none() is not None
+
     def create_photo(self, gallery_id: uuid.UUID, object_key: str, thumbnail_object_key: str, file_size: int, width: int | None = None, height: int | None = None) -> Photo:
         photo = Photo(gallery_id=gallery_id, object_key=object_key, thumbnail_object_key=thumbnail_object_key, file_size=file_size, width=width, height=height)
         self.db.add(photo)

--- a/tests/test_photo_api.py
+++ b/tests/test_photo_api.py
@@ -188,6 +188,36 @@ class TestPhotoAPI:
         assert not item["success"]
         assert "File exceeds maximum size" in item["error"]
 
+
+    def test_batch_presigned_uploads_rejects_duplicate_names(self, authenticated_client: TestClient, gallery_id_fixture: str):
+        """Duplicate filenames within the same gallery are rejected."""
+        upload_photo_via_presigned(authenticated_client, gallery_id_fixture, b"existing", "existing.jpg")
+
+        payload = {"files": [{"filename": "existing.jpg", "file_size": 128, "content_type": "image/jpeg"}]}
+        response = authenticated_client.post(f"/galleries/{gallery_id_fixture}/photos/batch-presigned", json=payload)
+
+        assert response.status_code == 200
+        item = response.json()["items"][0]
+        assert item["success"] is False
+        assert item["error"] == "A photo with this name already exists in this gallery."
+
+    def test_batch_presigned_uploads_rejects_duplicate_names_within_request(self, authenticated_client: TestClient, gallery_id_fixture: str):
+        """Duplicate filenames inside one upload request are rejected for later items."""
+        payload = {
+            "files": [
+                {"filename": "dupe.jpg", "file_size": 128, "content_type": "image/jpeg"},
+                {"filename": "dupe.jpg", "file_size": 256, "content_type": "image/jpeg"},
+            ]
+        }
+
+        response = authenticated_client.post(f"/galleries/{gallery_id_fixture}/photos/batch-presigned", json=payload)
+
+        assert response.status_code == 200
+        first, second = response.json()["items"]
+        assert first["success"] is True
+        assert second["success"] is False
+        assert second["error"] == "A photo with this name already exists in this gallery."
+
     def test_batch_confirm_uploads_updates_counts_and_triggers_task(self, authenticated_client: TestClient, gallery_id_fixture: str, monkeypatch):
         """Confirming uploads updates counts and schedules thumbnail task."""
         payload = {"files": [{"filename": "confirm.jpg", "file_size": 256, "content_type": "image/jpeg"}]}
@@ -243,6 +273,20 @@ class TestPhotoAPI:
         data = response.json()
         assert data["id"] == photo_id
         assert data["filename"] == "new-name.jpg"
+
+
+    def test_rename_photo_duplicate_name_in_gallery(self, authenticated_client: TestClient, gallery_id_fixture: str):
+        """Renaming to an existing filename in the same gallery is rejected."""
+        original_photo_id = upload_photo_via_presigned(authenticated_client, gallery_id_fixture, b"first", "first.jpg")
+        upload_photo_via_presigned(authenticated_client, gallery_id_fixture, b"second", "second.jpg")
+
+        response = authenticated_client.patch(
+            f"/galleries/{gallery_id_fixture}/photos/{original_photo_id}/rename",
+            json={"filename": "second.jpg"},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "A photo with this name already exists in this gallery."
 
     def test_filename_utilities(self):
         """sanitize_filename and content-type helper behave predictably."""


### PR DESCRIPTION
### Motivation
- Prevent duplicate `display_name`/filenames inside the same gallery because they cause frontend rendering collisions and ZIP overwrite data loss.
- Provide deterministic validation and a clear error (`"A photo with this name already exists in this gallery."`) at the API level for both upload and rename flows.

### Description
- Added a DB-level unique constraint on `(gallery_id, object_key)` via SQLAlchemy and a new Alembic revision to enforce gallery-scoped uniqueness at the storage layer (`src/viewport/models/gallery.py`, `src/viewport/alembic/versions/2026_02_28_b1c2d3e4f5a6_add_unique_photo_name_per_gallery.py`).
- Added a repository helper `photo_name_exists_in_gallery` to check for collisions and support rename exclusion logic (`src/viewport/repositories/gallery_repository.py`).
- Implemented pre-checks and request-level deduplication in the batch presigned upload endpoint to reject names already present in the gallery or duplicated within the same request, returning 400 items with the required message (`src/viewport/api/photo.py`).
- Added filename collision check before rename and handled `IntegrityError` races to return `400` with the same error message (`src/viewport/api/photo.py`).
- Introduced a shared constant `DUPLICATE_PHOTO_NAME_ERROR` and added tests for duplicate upload and rename behavior (`tests/test_photo_api.py`).

### Testing
- Ran linter/formatter checks with `uv run ruff check ...` which passed locally for the modified files. ✅
- Added unit/api tests in `tests/test_photo_api.py` covering duplicate upload against existing gallery files, duplicate filenames inside a single request, and duplicate rename; these tests were added to the suite but full `pytest` execution failed in this environment due to external dependencies (Docker/testcontainers and boto3) not being available, causing the test run to error (environment limitation). ⚠️
- The code paths guard for DB races by catching `IntegrityError` and returning `400` when the DB uniqueness constraint is violated. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a32f0591408332a284c1ec149113de)