### PR TITLE
Refactor zip entry name utilities and enhance tests

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -98,6 +98,7 @@
 
 ## Gotchas worth keeping in mind
 - Presigned URL cache is Redis-backed with a TTL buffer (URL TTL minus 10 minutes). Redis outages should degrade gracefully to direct presign generation without failing requests.
+- Shared ZIP filename sanitization/fallback/deduplication helpers live in `src/viewport/zip_utils.py` and are reused by both private (`api/gallery.py`) and public (`api/public.py`) download endpoints.
 
 ## Important rules
 - When making significant changes in the project, update this file to reflect new conventions or architectural patterns.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -81,6 +81,13 @@
   - Format + autofix: `just pretty` / `make pretty` (Ruff).
   - Typecheck: `just mypy`.
   - Tests: `just test` (pytest-xdist `-n 4`), coverage gate in `just test-cov` (fail-under 85).
+  - **Testcontainers fixture usage (required)**:
+    - Keep container fixtures session-scoped and shared per worker where possible (`_postgres_server`, `postgres_container`, `s3_container`, `valkey_container` in `tests/conftest.py`).
+    - Do not start heavy containers globally unless needed: gate expensive setup with fixture usage checks/markers (e.g., `_needs_db_for_request`, `_needs_s3_for_request`, `@pytest.mark.requires_s3`).
+    - For S3-backed API tests, mark modules/tests with `@pytest.mark.requires_s3` so per-test isolated buckets are created only when real object storage is required.
+    - Prefer dynamic DB/session overrides via existing `app_client`/`client` fixtures; avoid creating new container-per-test fixtures.
+    - Preserve isolation by keeping per-test DB cleanup (`TRUNCATE ... CASCADE`) and per-test S3 bucket isolation in place for tests that touch those resources.
+    - If adding new integration tests, reuse existing container fixtures first; introduce new testcontainers only when mocking cannot validate required behavior.
 - Frontend checks: `cd frontend && npm run lint -- --fix && npm run test:run`.
 
 ## Service Architecture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,9 @@ pythonpath = "."
 addopts = ["--import-mode=importlib", "-v"]
 asyncio_mode = "auto"
 testpaths = ["/tests"]
+markers = [
+    "requires_s3: tests that need real S3 object storage operations",
+]
 norecursedirs = [
     "postgres_data",
     ".git",

--- a/src/viewport/api/auth.py
+++ b/src/viewport/api/auth.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import UTC, datetime, timedelta
+from os import getenv
 
 import bcrypt
 import jwt
@@ -15,8 +16,27 @@ from viewport.schemas.auth import LoginRequest, LoginResponse, RefreshRequest, R
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
-# A dummy hash to use when the user is not found, to prevent timing attacks
-DUMMY_HASH = "$2b$12$t1mLmH3zKxUqFT8nM5cUHO4tbsrgn90vkUwJW09eORUeBLst9.YFC"
+_DEFAULT_BCRYPT_ROUNDS = 12
+_MIN_BCRYPT_ROUNDS = 4
+_MAX_BCRYPT_ROUNDS = 31
+
+
+def _resolve_bcrypt_rounds() -> int:
+    raw_value = getenv("BCRYPT_ROUNDS")
+    if raw_value is None:
+        return _DEFAULT_BCRYPT_ROUNDS
+
+    try:
+        rounds = int(raw_value)
+    except ValueError:
+        return _DEFAULT_BCRYPT_ROUNDS
+
+    return max(_MIN_BCRYPT_ROUNDS, min(_MAX_BCRYPT_ROUNDS, rounds))
+
+
+_BCRYPT_ROUNDS = _resolve_bcrypt_rounds()
+# A dummy hash to use when the user is not found, to prevent timing attacks.
+DUMMY_HASH = bcrypt.hashpw(b"viewport-dummy-password", bcrypt.gensalt(rounds=_BCRYPT_ROUNDS)).decode("utf-8")
 
 
 def get_user_repository(db: AsyncSession = Depends(get_db)) -> UserRepository:
@@ -25,7 +45,7 @@ def get_user_repository(db: AsyncSession = Depends(get_db)) -> UserRepository:
 
 def hash_password(password: str) -> str:
     """Hash a password using bcrypt with a random salt."""
-    return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+    return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt(rounds=_BCRYPT_ROUNDS)).decode("utf-8")
 
 
 def verify_password(password: str, hashed: str) -> bool:
@@ -34,12 +54,26 @@ def verify_password(password: str, hashed: str) -> bool:
 
 
 def create_access_token(user_id: str) -> str:
-    payload = {"sub": user_id, "exp": datetime.now(UTC) + timedelta(minutes=authsettings.access_token_expire_minutes), "type": "access"}
+    issued_at = datetime.now(UTC)
+    payload = {
+        "sub": user_id,
+        "iat": issued_at,
+        "exp": issued_at + timedelta(minutes=authsettings.access_token_expire_minutes),
+        "type": "access",
+        "jti": str(uuid.uuid4()),
+    }
     return jwt.encode(payload, authsettings.jwt_secret_key, algorithm=authsettings.jwt_algorithm)
 
 
 def create_refresh_token(user_id: str) -> str:
-    payload = {"sub": user_id, "exp": datetime.now(UTC) + timedelta(minutes=authsettings.refresh_token_expire_minutes), "type": "refresh"}
+    issued_at = datetime.now(UTC)
+    payload = {
+        "sub": user_id,
+        "iat": issued_at,
+        "exp": issued_at + timedelta(minutes=authsettings.refresh_token_expire_minutes),
+        "type": "refresh",
+        "jti": str(uuid.uuid4()),
+    }
     return jwt.encode(payload, authsettings.jwt_secret_key, algorithm=authsettings.jwt_algorithm)
 
 

--- a/src/viewport/api/gallery.py
+++ b/src/viewport/api/gallery.py
@@ -9,7 +9,6 @@ from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.concurrency import run_in_threadpool
 
-from viewport.api.public import _build_zip_fallback_name, _make_unique_zip_entry_name, _sanitize_zip_entry_name
 from viewport.auth_utils import get_current_user, get_current_user_for_download
 from viewport.background_tasks import delete_gallery_data_task
 from viewport.dependencies import get_s3_client as get_async_s3_client
@@ -31,6 +30,7 @@ from viewport.schemas.gallery import (
     SortOrder,
 )
 from viewport.schemas.photo import DownloadSelectedPhotosRequest, GalleryPhotoResponse
+from viewport.zip_utils import build_zip_fallback_name, make_unique_zip_entry_name, sanitize_zip_entry_name
 
 router = APIRouter(prefix="/galleries", tags=["galleries"])
 logger = logging.getLogger(__name__)
@@ -291,9 +291,9 @@ def _build_gallery_zip_response(gallery_id: uuid.UUID, photos: list, archive_nam
 
     for photo in photos:
         object_key = photo.object_key
-        fallback = _build_zip_fallback_name(photo.display_name, object_key=object_key, fallback_stem=f"photo-{photo.id}")
-        filename = _sanitize_zip_entry_name(photo.display_name, fallback=fallback)
-        filename = _make_unique_zip_entry_name(filename, used_names)
+        fallback = build_zip_fallback_name(photo.display_name, object_key=object_key, fallback_stem=f"photo-{photo.id}")
+        filename = sanitize_zip_entry_name(photo.display_name, fallback=fallback)
+        filename = make_unique_zip_entry_name(filename, used_names)
 
         def file_generator(key: str = object_key):
             client = get_sync_s3_client()

--- a/src/viewport/api/photo.py
+++ b/src/viewport/api/photo.py
@@ -1,5 +1,4 @@
 import logging
-from pathlib import Path
 from uuid import UUID, uuid4
 
 from botocore.exceptions import ClientError
@@ -10,7 +9,7 @@ from starlette.concurrency import run_in_threadpool
 from viewport.auth_utils import get_current_user
 from viewport.background_tasks import create_thumbnails_batch_task, delete_photos_batch_task
 from viewport.dependencies import get_s3_client
-from viewport.filename_utils import sanitize_filename
+from viewport.filename_utils import sanitize_filename, split_name_and_ext
 from viewport.models.db import get_db
 from viewport.models.gallery import PhotoUploadStatus
 from viewport.models.user import User
@@ -68,13 +67,6 @@ def get_gallery_repository(db: AsyncSession = Depends(get_db)) -> GalleryReposit
 
 def get_user_repository(db: AsyncSession = Depends(get_db)) -> UserRepository:
     return UserRepository(db)
-
-
-def split_name_and_ext(filename: str) -> tuple[str, str]:
-    path = Path(filename)
-    suffix = path.suffix if path.suffix else ""
-    stem = path.stem if path.stem else "file"
-    return stem, suffix
 
 
 def make_unique_display_name(filename: str, occupied_names: set[str]) -> str:

--- a/src/viewport/api/public.py
+++ b/src/viewport/api/public.py
@@ -1,8 +1,5 @@
 import contextlib
-import re
-import unicodedata
 from asyncio import run as asyncio_run
-from pathlib import Path
 from uuid import UUID
 
 import zipstream
@@ -11,7 +8,6 @@ from fastapi.responses import StreamingResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from viewport.api.photo import CONTENT_TYPE_MAP
 from viewport.dependencies import get_s3_client as get_async_s3_client
 from viewport.logger import logger
 from viewport.models.db import get_db
@@ -23,6 +19,7 @@ from viewport.s3_utils import get_s3_client, get_s3_settings
 from viewport.schemas.gallery import GalleryPhotoSortBy, SortOrder
 from viewport.schemas.public import PublicCover, PublicGalleryResponse, PublicPhoto
 from viewport.sharelink_utils import is_sharelink_expired
+from viewport.zip_utils import build_zip_fallback_name, make_unique_zip_entry_name, sanitize_zip_entry_name
 
 router = APIRouter(prefix="/s", tags=["public"])
 PUBLIC_CACHE_CONTROL_HEADERS = {
@@ -31,139 +28,10 @@ PUBLIC_CACHE_CONTROL_HEADERS = {
     "Expires": "0",
 }
 
-_WINDOWS_RESERVED_NAMES = {
-    "con",
-    "prn",
-    "aux",
-    "nul",
-    "com1",
-    "com2",
-    "com3",
-    "com4",
-    "com5",
-    "com6",
-    "com7",
-    "com8",
-    "com9",
-    "lpt1",
-    "lpt2",
-    "lpt3",
-    "lpt4",
-    "lpt5",
-    "lpt6",
-    "lpt7",
-    "lpt8",
-    "lpt9",
-}
-_SEPARATOR_LIKE_CHARS = {"/", "\\", "\u2215", "\u2044"}
-_FORBIDDEN_ZIP_CHARS_RE = re.compile(r'[<>:"|?*\x00-\x1F]')
-_WHITESPACE_RE = re.compile(r"\s+")
-_WINDOWS_DRIVE_PREFIX_RE = re.compile(r"^[A-Za-z]:")
-_MAX_ZIP_ENTRY_NAME_BYTES = 255
-_EXTENSION_ONLY_TOKENS = {ext.lstrip(".") for ext in CONTENT_TYPE_MAP}
-
 
 def _build_content_disposition(filename: str, disposition_type: str = "inline") -> str:
     safe_filename = filename.replace("\\", "\\\\").replace('"', '\\"')
     return f'{disposition_type}; filename="{safe_filename}"'
-
-
-def _split_name_and_ext(filename: str) -> tuple[str, str]:
-    path = Path(filename)
-    suffix = path.suffix if path.suffix else ""
-    stem = path.stem if path.stem else "file"
-    return stem, suffix
-
-
-def _truncate_utf8(value: str, max_bytes: int) -> str:
-    if max_bytes <= 0:
-        return ""
-    encoded = value.encode("utf-8")
-    if len(encoded) <= max_bytes:
-        return value
-    truncated = encoded[:max_bytes]
-    return truncated.decode("utf-8", errors="ignore")
-
-
-def _truncate_preserving_extension(filename: str, max_bytes: int = _MAX_ZIP_ENTRY_NAME_BYTES) -> str:
-    if len(filename.encode("utf-8")) <= max_bytes:
-        return filename
-
-    stem, suffix = _split_name_and_ext(filename)
-    suffix_bytes = len(suffix.encode("utf-8"))
-
-    if suffix_bytes >= max_bytes:
-        return _truncate_utf8(stem, max_bytes)
-
-    stem_max_bytes = max_bytes - suffix_bytes
-    truncated_stem = _truncate_utf8(stem, stem_max_bytes).rstrip(" .")
-    if not truncated_stem:
-        truncated_stem = "file"
-    return f"{truncated_stem}{suffix}"
-
-
-def _sanitize_zip_entry_name(filename: str, fallback: str) -> str:
-    normalized = unicodedata.normalize("NFKC", filename or "")
-    cleaned = "".join(ch for ch in normalized if unicodedata.category(ch)[0] != "C").strip()
-    if not cleaned:
-        return fallback
-
-    if any(separator in cleaned for separator in _SEPARATOR_LIKE_CHARS):
-        return fallback
-
-    if _WINDOWS_DRIVE_PREFIX_RE.match(cleaned):
-        return fallback
-
-    sanitized = _FORBIDDEN_ZIP_CHARS_RE.sub("_", cleaned)
-    sanitized = _WHITESPACE_RE.sub(" ", sanitized).strip(" .")
-
-    if not sanitized or sanitized in {".", ".."}:
-        return fallback
-
-    if "." not in sanitized and sanitized.casefold() in _EXTENSION_ONLY_TOKENS:
-        return fallback
-
-    stem, _ = _split_name_and_ext(sanitized)
-    if stem.casefold() in _WINDOWS_RESERVED_NAMES:
-        return fallback
-
-    sanitized = _truncate_preserving_extension(sanitized)
-    if not sanitized or sanitized in {".", ".."}:
-        return fallback
-
-    return sanitized
-
-
-def _build_zip_fallback_name(filename: str, object_key: str, fallback_stem: str) -> str:
-    normalized = unicodedata.normalize("NFKC", filename or "")
-    leaf = normalized.replace("\\", "/").rsplit("/", 1)[-1]
-    extension = Path(leaf).suffix.lower()
-    if extension in CONTENT_TYPE_MAP:
-        return f"{fallback_stem}{extension}"
-
-    object_key_extension = Path(object_key).suffix.lower()
-    if object_key_extension in CONTENT_TYPE_MAP:
-        return f"{fallback_stem}{object_key_extension}"
-
-    return f"{fallback_stem}.jpg"
-
-
-def _make_unique_zip_entry_name(filename: str, used_names: set[str]) -> str:
-    candidate = filename
-    stem, suffix = _split_name_and_ext(filename)
-    counter = 1
-
-    while candidate.casefold() in used_names:
-        suffix_part = f" ({counter})"
-        stem_budget = _MAX_ZIP_ENTRY_NAME_BYTES - len(suffix.encode("utf-8"))
-        candidate_stem = _truncate_utf8(f"{stem}{suffix_part}", stem_budget).rstrip(" .")
-        if not candidate_stem:
-            candidate_stem = "file"
-        candidate = f"{candidate_stem}{suffix}"
-        counter += 1
-
-    used_names.add(candidate.casefold())
-    return candidate
 
 
 def _resolve_public_sorting(gallery: Gallery) -> tuple[GalleryPhotoSortBy, SortOrder]:
@@ -340,9 +208,9 @@ def download_all_photos_zip(
 
     for photo in photos:
         key = photo.object_key
-        fallback = _build_zip_fallback_name(photo.display_name, object_key=key, fallback_stem=f"photo-{photo.id}")
-        filename = _sanitize_zip_entry_name(photo.display_name, fallback=fallback)
-        filename = _make_unique_zip_entry_name(filename, used_names)
+        fallback = build_zip_fallback_name(photo.display_name, object_key=key, fallback_stem=f"photo-{photo.id}")
+        filename = sanitize_zip_entry_name(photo.display_name, fallback=fallback)
+        filename = make_unique_zip_entry_name(filename, used_names)
 
         def file_generator(object_key: str = key):
             client = get_s3_client()

--- a/src/viewport/filename_utils.py
+++ b/src/viewport/filename_utils.py
@@ -1,4 +1,5 @@
 import re
+from pathlib import Path
 
 
 def sanitize_filename(filename: str) -> str:
@@ -18,3 +19,38 @@ def sanitize_filename(filename: str) -> str:
         filename = "file"
 
     return filename
+
+
+def split_name_and_ext(filename: str) -> tuple[str, str]:
+    path = Path(filename)
+    suffix = path.suffix if path.suffix else ""
+    stem = path.stem if path.stem else "file"
+    return stem, suffix
+
+
+def truncate_utf8(value: str, max_bytes: int) -> str:
+    if max_bytes <= 0:
+        return ""
+
+    encoded = value.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return value
+
+    return encoded[:max_bytes].decode("utf-8", errors="ignore")
+
+
+def truncate_preserving_extension(filename: str, max_bytes: int = 255) -> str:
+    if len(filename.encode("utf-8")) <= max_bytes:
+        return filename
+
+    stem, suffix = split_name_and_ext(filename)
+    suffix_bytes = len(suffix.encode("utf-8"))
+
+    if suffix_bytes >= max_bytes:
+        return truncate_utf8(stem, max_bytes)
+
+    stem_max_bytes = max_bytes - suffix_bytes
+    truncated_stem = truncate_utf8(stem, stem_max_bytes).rstrip(" .")
+    if not truncated_stem:
+        truncated_stem = "file"
+    return f"{truncated_stem}{suffix}"

--- a/src/viewport/repositories/gallery_repository.py
+++ b/src/viewport/repositories/gallery_repository.py
@@ -2,15 +2,15 @@ import logging
 import time
 import uuid
 from datetime import UTC, date, datetime
-from pathlib import Path
 
 from sqlalchemy import asc, desc, func, insert, or_, select, update
 from sqlalchemy.exc import IntegrityError
 
-from viewport.filename_utils import sanitize_filename
+from viewport.filename_utils import sanitize_filename, split_name_and_ext
 from viewport.models.gallery import Gallery, Photo, PhotoUploadStatus
 from viewport.models.sharelink import ShareLink
 from viewport.repositories.base_repository import BaseRepository
+from viewport.repositories.photo_query_helpers import build_photo_order_clauses
 from viewport.repositories.user_repository import UserRepository
 from viewport.s3_service import AsyncS3Client
 from viewport.schemas.gallery import GalleryListSortBy, GalleryPhotoSortBy, SortOrder
@@ -33,19 +33,6 @@ class GalleryRepository(BaseRepository):
             escaped_search = GalleryRepository._escape_like_term(search)
             filters.append(Photo.display_name.ilike(f"%{escaped_search}%", escape=GalleryRepository.LIKE_ESCAPE_CHAR))
         return filters
-
-    @staticmethod
-    def _build_photo_order_clauses(sort_by: GalleryPhotoSortBy, order: SortOrder):
-        order_fn = asc if order == SortOrder.ASC else desc
-
-        if sort_by == GalleryPhotoSortBy.ORIGINAL_FILENAME:
-            primary_column = func.lower(Photo.display_name)
-            return [order_fn(primary_column), order_fn(Photo.uploaded_at), order_fn(Photo.id)]
-
-        if sort_by == GalleryPhotoSortBy.FILE_SIZE:
-            return [order_fn(Photo.file_size), order_fn(Photo.uploaded_at), order_fn(Photo.id)]
-
-        return [order_fn(Photo.uploaded_at), order_fn(Photo.id)]
 
     @staticmethod
     def _build_gallery_order_clauses(
@@ -71,13 +58,6 @@ class GalleryRepository(BaseRepository):
 
         return [order_fn(Gallery.created_at), order_fn(Gallery.id)]
 
-    @staticmethod
-    def _split_name_and_ext(filename: str) -> tuple[str, str]:
-        path = Path(filename)
-        suffix = path.suffix if path.suffix else ""
-        stem = path.stem if path.stem else "file"
-        return stem, suffix
-
     async def _make_unique_display_name(self, gallery_id: uuid.UUID, desired_name: str, exclude_photo_id: uuid.UUID | None = None) -> str:
         # Get all occupied names in case-insensitive way for this gallery
         stmt = select(Photo.display_name).join(Photo.gallery).where(Photo.gallery_id == gallery_id, Gallery.is_deleted.is_(False))
@@ -88,7 +68,7 @@ class GalleryRepository(BaseRepository):
         occupied_names_lower = {name.lower() for name in (await self.db.execute(stmt)).scalars().all() if name}
 
         candidate = desired_name
-        stem, suffix = self._split_name_and_ext(candidate)
+        stem, suffix = split_name_and_ext(candidate)
 
         counter = 1
         while candidate.lower() in occupied_names_lower:
@@ -490,7 +470,7 @@ class GalleryRepository(BaseRepository):
         sort_by: GalleryPhotoSortBy = GalleryPhotoSortBy.UPLOADED_AT,
         order: SortOrder = SortOrder.DESC,
     ) -> list[Photo]:
-        stmt = select(Photo).join(Photo.gallery).where(*self._build_photo_filters(gallery_id, search)).order_by(*self._build_photo_order_clauses(sort_by, order)).offset(offset)
+        stmt = select(Photo).join(Photo.gallery).where(*self._build_photo_filters(gallery_id, search)).order_by(*build_photo_order_clauses(sort_by, order)).offset(offset)
         if limit is not None:
             stmt = stmt.limit(limit)
         photos = list((await self.db.execute(stmt)).scalars().all())
@@ -627,7 +607,7 @@ class GalleryRepository(BaseRepository):
 
                     occupied_names_lower = occupied_names_by_gallery[gallery_id]
                     candidate = desired_name
-                    stem, suffix = self._split_name_and_ext(candidate)
+                    stem, suffix = split_name_and_ext(candidate)
 
                     counter = 1
                     while candidate.lower() in occupied_names_lower:

--- a/src/viewport/repositories/photo_query_helpers.py
+++ b/src/viewport/repositories/photo_query_helpers.py
@@ -1,0 +1,30 @@
+from sqlalchemy import asc, desc, func
+
+from viewport.models.gallery import Photo
+from viewport.schemas.gallery import GalleryPhotoSortBy, SortOrder
+
+
+def build_photo_order_clauses(
+    sort_by: GalleryPhotoSortBy,
+    order: SortOrder,
+    *,
+    include_uploaded_at_tiebreaker: bool = True,
+):
+    order_fn = asc if order == SortOrder.ASC else desc
+
+    if sort_by == GalleryPhotoSortBy.ORIGINAL_FILENAME:
+        primary_column = func.lower(Photo.display_name)
+        clauses = [order_fn(primary_column)]
+        if include_uploaded_at_tiebreaker:
+            clauses.append(order_fn(Photo.uploaded_at))
+        clauses.append(order_fn(Photo.id))
+        return clauses
+
+    if sort_by == GalleryPhotoSortBy.FILE_SIZE:
+        clauses = [order_fn(Photo.file_size)]
+        if include_uploaded_at_tiebreaker:
+            clauses.append(order_fn(Photo.uploaded_at))
+        clauses.append(order_fn(Photo.id))
+        return clauses
+
+    return [order_fn(Photo.uploaded_at), order_fn(Photo.id)]

--- a/src/viewport/repositories/sharelink_repository.py
+++ b/src/viewport/repositories/sharelink_repository.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import UTC, date, datetime, timedelta
 from hashlib import sha256
 
-from sqlalchemy import String, and_, asc, case, cast, desc, func, or_, select, update
+from sqlalchemy import String, and_, case, cast, func, or_, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import selectinload
 
@@ -10,24 +10,12 @@ from viewport.models.gallery import Gallery, Photo
 from viewport.models.sharelink import ShareLink
 from viewport.models.sharelink_analytics import ShareLinkDailyStat, ShareLinkDailyVisitor
 from viewport.repositories.base_repository import BaseRepository
+from viewport.repositories.photo_query_helpers import build_photo_order_clauses
 from viewport.schemas.gallery import GalleryPhotoSortBy, SortOrder
 from viewport.sharelink_utils import is_sharelink_expired
 
 
 class ShareLinkRepository(BaseRepository):
-    @staticmethod
-    def _build_public_photo_order_clauses(sort_by: GalleryPhotoSortBy, order: SortOrder):
-        order_fn = asc if order == SortOrder.ASC else desc
-
-        if sort_by == GalleryPhotoSortBy.UPLOADED_AT:
-            return [order_fn(Photo.uploaded_at), order_fn(Photo.id)]
-
-        if sort_by == GalleryPhotoSortBy.FILE_SIZE:
-            return [order_fn(Photo.file_size), order_fn(Photo.id)]
-
-        # Default: filename ordering for stable public presentation.
-        return [order_fn(func.lower(Photo.display_name)), order_fn(Photo.id)]
-
     async def get_sharelink_by_id(self, sharelink_id: uuid.UUID) -> ShareLink | None:
         stmt = select(ShareLink).where(ShareLink.id == sharelink_id)
         sharelink = (await self.db.execute(stmt)).scalar_one_or_none()
@@ -141,7 +129,13 @@ class ShareLinkRepository(BaseRepository):
     ) -> list[Photo]:
         from viewport.models.gallery import Gallery
 
-        stmt = select(Photo).join(Photo.gallery).where(Photo.gallery_id == gallery_id, Gallery.is_deleted.is_(False)).order_by(*self._build_public_photo_order_clauses(sort_by, order)).offset(offset)
+        stmt = (
+            select(Photo)
+            .join(Photo.gallery)
+            .where(Photo.gallery_id == gallery_id, Gallery.is_deleted.is_(False))
+            .order_by(*build_photo_order_clauses(sort_by, order, include_uploaded_at_tiebreaker=False))
+            .offset(offset)
+        )
         if limit is not None:
             stmt = stmt.limit(limit)
 

--- a/src/viewport/zip_utils.py
+++ b/src/viewport/zip_utils.py
@@ -1,0 +1,101 @@
+import re
+import unicodedata
+from pathlib import Path
+
+from viewport.filename_utils import split_name_and_ext, truncate_preserving_extension, truncate_utf8
+
+_ALLOWED_IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png"}
+_WINDOWS_RESERVED_NAMES = {
+    "con",
+    "prn",
+    "aux",
+    "nul",
+    "com1",
+    "com2",
+    "com3",
+    "com4",
+    "com5",
+    "com6",
+    "com7",
+    "com8",
+    "com9",
+    "lpt1",
+    "lpt2",
+    "lpt3",
+    "lpt4",
+    "lpt5",
+    "lpt6",
+    "lpt7",
+    "lpt8",
+    "lpt9",
+}
+_SEPARATOR_LIKE_CHARS = {"/", "\\", "\u2215", "\u2044"}
+_FORBIDDEN_ZIP_CHARS_RE = re.compile(r'[<>:"|?*\x00-\x1F]')
+_WHITESPACE_RE = re.compile(r"\s+")
+_WINDOWS_DRIVE_PREFIX_RE = re.compile(r"^[A-Za-z]:")
+_MAX_ZIP_ENTRY_NAME_BYTES = 255
+_EXTENSION_ONLY_TOKENS = {ext.lstrip(".") for ext in _ALLOWED_IMAGE_EXTENSIONS}
+
+
+def sanitize_zip_entry_name(filename: str, fallback: str) -> str:
+    normalized = unicodedata.normalize("NFKC", filename or "")
+    cleaned = "".join(ch for ch in normalized if unicodedata.category(ch)[0] != "C").strip()
+    if not cleaned:
+        return fallback
+
+    if any(separator in cleaned for separator in _SEPARATOR_LIKE_CHARS):
+        return fallback
+
+    if _WINDOWS_DRIVE_PREFIX_RE.match(cleaned):
+        return fallback
+
+    sanitized = _FORBIDDEN_ZIP_CHARS_RE.sub("_", cleaned)
+    sanitized = _WHITESPACE_RE.sub(" ", sanitized).strip(" .")
+
+    if not sanitized or sanitized in {".", ".."}:
+        return fallback
+
+    if "." not in sanitized and sanitized.casefold() in _EXTENSION_ONLY_TOKENS:
+        return fallback
+
+    stem, _ = split_name_and_ext(sanitized)
+    if stem.casefold() in _WINDOWS_RESERVED_NAMES:
+        return fallback
+
+    sanitized = truncate_preserving_extension(sanitized, max_bytes=_MAX_ZIP_ENTRY_NAME_BYTES)
+    if not sanitized or sanitized in {".", ".."}:
+        return fallback
+
+    return sanitized
+
+
+def build_zip_fallback_name(filename: str, object_key: str, fallback_stem: str) -> str:
+    normalized = unicodedata.normalize("NFKC", filename or "")
+    leaf = normalized.replace("\\", "/").rsplit("/", 1)[-1]
+    extension = Path(leaf).suffix.lower()
+    if extension in _ALLOWED_IMAGE_EXTENSIONS:
+        return f"{fallback_stem}{extension}"
+
+    object_key_extension = Path(object_key).suffix.lower()
+    if object_key_extension in _ALLOWED_IMAGE_EXTENSIONS:
+        return f"{fallback_stem}{object_key_extension}"
+
+    return f"{fallback_stem}.jpg"
+
+
+def make_unique_zip_entry_name(filename: str, used_names: set[str]) -> str:
+    candidate = filename
+    stem, suffix = split_name_and_ext(filename)
+    counter = 1
+
+    while candidate.casefold() in used_names:
+        suffix_part = f" ({counter})"
+        stem_budget = _MAX_ZIP_ENTRY_NAME_BYTES - len(suffix.encode("utf-8"))
+        candidate_stem = truncate_utf8(f"{stem}{suffix_part}", stem_budget).rstrip(" .")
+        if not candidate_stem:
+            candidate_stem = "file"
+        candidate = f"{candidate_stem}{suffix}"
+        counter += 1
+
+    used_names.add(candidate.casefold())
+    return candidate

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,8 +30,14 @@ S3_ROOT_SECRET_KEY = "testsecretkey"
 S3_PORT = 9000
 VALKEY_IMAGE = "valkey/valkey:8-alpine"
 VALKEY_PORT = 6379
-S3_TRIGGER_FIXTURES = {
-    "s3_container",
+S3_TRIGGER_FIXTURES = {"s3_container"}
+DB_TRIGGER_FIXTURES = {
+    "postgres_container",
+    "async_engine",
+    "sync_engine",
+    "engine",
+    "db_session",
+    "app_client",
     "client",
     "authenticated_client",
     "auth_token",
@@ -55,6 +61,7 @@ os.environ.update(
         "JWT_SECRET_KEY": "supersecretkeysupersecretkeysupersecretkey",
         "ADMIN_JWT_SECRET_KEY": "adminsecretkeyadminsecretkeyadminsecretkey",
         "INVITE_CODE": "testinvitecode",
+        "BCRYPT_ROUNDS": "4",
         "ENVIRONMENT": "pytest",
     }
 )
@@ -378,7 +385,13 @@ def _refresh_app_s3_client_instance() -> None:
 
 
 def _needs_s3_for_request(request: pytest.FixtureRequest) -> bool:
-    return bool(S3_TRIGGER_FIXTURES.intersection(request.fixturenames))
+    if S3_TRIGGER_FIXTURES.intersection(request.fixturenames):
+        return True
+    return request.node.get_closest_marker("requires_s3") is not None
+
+
+def _needs_db_for_request(request: pytest.FixtureRequest) -> bool:
+    return bool(DB_TRIGGER_FIXTURES.intersection(request.fixturenames))
 
 
 @pytest.fixture(scope="session")
@@ -494,9 +507,14 @@ def sync_engine(postgres_container: PostgresConnectionInfo) -> Generator[Engine]
 
 
 @pytest.fixture(autouse=True)
-def _cleanup_database(async_engine: AsyncEngine, request) -> None:
+def _cleanup_database(request: pytest.FixtureRequest) -> None:
     """Clear all tables before each test to keep isolation simple with AsyncSession."""
+    if not _needs_db_for_request(request):
+        return
+
     from viewport.models.db import Base
+
+    async_engine = request.getfixturevalue("async_engine")
 
     async def _truncate() -> None:
         async with async_engine.begin() as conn:
@@ -595,7 +613,7 @@ def valkey_container(request: pytest.FixtureRequest) -> Generator[str]:
         container.stop()
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session")
 def _redis_test_env(valkey_container: str) -> Generator[None]:
     with _temporary_env_vars({"REDIS_URL": valkey_container}):
         from viewport.services.redis_service import get_redis_settings
@@ -615,7 +633,6 @@ def _db_session_holder() -> dict[str, AsyncSession | None]:
 @pytest.fixture(scope="session")
 def app_client(
     postgres_container: PostgresConnectionInfo,
-    s3_container: S3ConnectionInfo | DockerContainer,
     _redis_test_env: None,
     _db_session_holder: dict[str, AsyncSession | None],
 ):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -171,11 +171,6 @@ class TestAuthFlow:
         refresh_token = tokens["refresh_token"]
         original_access_token = tokens["access_token"]
 
-        # Add small delay to ensure different timestamps
-        import time
-
-        time.sleep(1)
-
         # Refresh token
         refresh_payload = {"refresh_token": refresh_token}
         refresh_response = client.post("/auth/refresh", json=refresh_payload)

--- a/tests/test_gallery_api.py
+++ b/tests/test_gallery_api.py
@@ -6,10 +6,13 @@ from datetime import date
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
+import pytest
 from fastapi.testclient import TestClient
 
 from tests.helpers import register_and_login, upload_photo_via_presigned
 from viewport.gallery_constants import GALLERY_NAME_MAX_LENGTH, PHOTO_SEARCH_MAX_LENGTH
+
+pytestmark = pytest.mark.requires_s3
 
 
 class TestGalleryAPI:

--- a/tests/test_photo_api.py
+++ b/tests/test_photo_api.py
@@ -16,6 +16,8 @@ from viewport.models.user import User
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
+pytestmark = pytest.mark.requires_s3
+
 
 class TestPhotoAPI:
     """Test photo API endpoints with comprehensive coverage."""

--- a/tests/test_photo_api.py
+++ b/tests/test_photo_api.py
@@ -6,7 +6,6 @@ from uuid import UUID, uuid4
 
 import pytest
 import requests
-from fastapi.testclient import TestClient
 
 from tests.helpers import register_and_login, upload_photo_via_presigned
 from viewport.api.photo import MAX_FILE_SIZE, _invalidate_presigned_cache_safely, get_content_type_from_filename, sanitize_filename
@@ -14,6 +13,7 @@ from viewport.models.gallery import Photo, PhotoUploadStatus
 from viewport.models.user import User
 
 if TYPE_CHECKING:
+    from fastapi.testclient import TestClient
     from sqlalchemy.ext.asyncio import AsyncSession
 
 pytestmark = pytest.mark.requires_s3

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -12,6 +12,8 @@ from tests.helpers import upload_photo_via_presigned
 from viewport.api.public import get_valid_sharelink
 from viewport.zip_utils import build_zip_fallback_name, make_unique_zip_entry_name, sanitize_zip_entry_name
 
+pytestmark = pytest.mark.requires_s3
+
 
 def _upload_photo(client: TestClient, gallery_id: str, content: bytes, filename: str = "photo.jpg") -> str:
     return upload_photo_via_presigned(client, gallery_id, content, filename)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -9,7 +9,8 @@ from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from tests.helpers import upload_photo_via_presigned
-from viewport.api.public import _build_zip_fallback_name, _make_unique_zip_entry_name, _sanitize_zip_entry_name, get_valid_sharelink
+from viewport.api.public import get_valid_sharelink
+from viewport.zip_utils import build_zip_fallback_name, make_unique_zip_entry_name, sanitize_zip_entry_name
 
 
 def _upload_photo(client: TestClient, gallery_id: str, content: bytes, filename: str = "photo.jpg") -> str:
@@ -244,20 +245,20 @@ class TestPublicAPI:
         ],
     )
     def test_sanitize_zip_entry_name_attack_matrix(self, raw_name: str, fallback: str, expected: str):
-        assert _sanitize_zip_entry_name(raw_name, fallback=fallback) == expected
+        assert sanitize_zip_entry_name(raw_name, fallback=fallback) == expected
 
     def test_sanitize_zip_entry_name_truncates_long_names(self):
         long_name = f"{'я' * 400}.jpeg"
-        sanitized = _sanitize_zip_entry_name(long_name, fallback="fallback.jpg")
+        sanitized = sanitize_zip_entry_name(long_name, fallback="fallback.jpg")
 
         assert sanitized.endswith(".jpeg")
         assert len(sanitized.encode("utf-8")) <= 255
 
     def test_make_unique_zip_entry_name_is_case_insensitive(self):
         used: set[str] = set()
-        first = _make_unique_zip_entry_name("A.jpg", used)
-        second = _make_unique_zip_entry_name("a.jpg", used)
-        third = _make_unique_zip_entry_name("a.jpg", used)
+        first = make_unique_zip_entry_name("A.jpg", used)
+        second = make_unique_zip_entry_name("a.jpg", used)
+        third = make_unique_zip_entry_name("a.jpg", used)
 
         assert first == "A.jpg"
         assert second == "a (1).jpg"
@@ -273,7 +274,7 @@ class TestPublicAPI:
         ],
     )
     def test_build_zip_fallback_name_uses_allowed_extensions(self, raw_name: str, object_key: str, fallback_stem: str, expected: str):
-        assert _build_zip_fallback_name(raw_name, object_key, fallback_stem) == expected
+        assert build_zip_fallback_name(raw_name, object_key, fallback_stem) == expected
 
     def test_download_all_zip_preserves_png_extension_in_fallback(self, authenticated_client: TestClient, gallery_id_fixture: str):
         content = b"zip-safe-content"


### PR DESCRIPTION
This pull request refactors and consolidates ZIP filename sanitization and deduplication logic into a new shared utility module, updates authentication token generation and password hashing for improved security and configurability, and clarifies test container usage conventions. It also cleans up duplicated code and improves maintainability by centralizing filename handling helpers.

**Test and Documentation Improvements**
- Added detailed guidelines for using testcontainers in integration tests, emphasizing session-scoped fixtures, resource isolation, and the use of pytest markers for S3-dependent tests in `.github/copilot-instructions.md`.
- Registered a new pytest marker `requires_s3` in `pyproject.toml` to clearly identify tests that require real S3 object storage.
- Documented the location and shared usage of ZIP filename helpers in `.github/copilot-instructions.md`.

**ZIP Filename Utilities Refactor**
- Moved and consolidated all ZIP filename sanitization, fallback, and deduplication helpers into a new `src/viewport/zip_utils.py` module, removing duplicated implementations from `api/public.py` and `api/gallery.py`. Updated both endpoints to use these shared helpers. [[1]](diffhunk://#diff-a4e3ac8022a341bd24af05b8966dc7343095da7e7c4350fa1291224d951119cdR33) [[2]](diffhunk://#diff-3a8f946fe32b5ff1c307338aa243935ef43610de3ff6015277f66c45a27a9b36R22) [[3]](diffhunk://#diff-3a8f946fe32b5ff1c307338aa243935ef43610de3ff6015277f66c45a27a9b36L343-R213)
- Removed legacy and duplicated ZIP filename logic from `api/public.py` and `api/gallery.py`, ensuring all ZIP-related filename handling is now consistent and maintainable. [[1]](diffhunk://#diff-3a8f946fe32b5ff1c307338aa243935ef43610de3ff6015277f66c45a27a9b36L34-L168) [[2]](diffhunk://#diff-a4e3ac8022a341bd24af05b8966dc7343095da7e7c4350fa1291224d951119cdL294-R296)

**Filename Utilities Generalization**
- Moved and generalized `split_name_and_ext`, `truncate_utf8`, and `truncate_preserving_extension` helpers into `src/viewport/filename_utils.py` for broader reuse across the codebase. [[1]](diffhunk://#diff-a7807ae2164ce5281cd944fe5f9dc72acfddc8a609942e75589f998ab7344e34R22-R56) [[2]](diffhunk://#diff-9d20501da66a35155b1bff34300c62427251b53ad4775609e3eeeb8067579c57L13-R12) [[3]](diffhunk://#diff-9d20501da66a35155b1bff34300c62427251b53ad4775609e3eeeb8067579c57L73-L79) [[4]](diffhunk://#diff-7e36b6721d7b56a20479cc2dcb4fa8acef3f472caffce0dfa18e12e00d110a08L5-R13) [[5]](diffhunk://#diff-7e36b6721d7b56a20479cc2dcb4fa8acef3f472caffce0dfa18e12e00d110a08L74-L80) [[6]](diffhunk://#diff-7e36b6721d7b56a20479cc2dcb4fa8acef3f472caffce0dfa18e12e00d110a08L91-R71)

**Authentication Improvements**
- Made bcrypt password hashing rounds configurable via the `BCRYPT_ROUNDS` environment variable, with safe defaults and bounds, to allow tuning for security/performance. [[1]](diffhunk://#diff-c769fa9b56157525d782609b351d22ab67374434a76a885b1778c4652b25f064R3) [[2]](diffhunk://#diff-c769fa9b56157525d782609b351d22ab67374434a76a885b1778c4652b25f064L18-R39) [[3]](diffhunk://#diff-c769fa9b56157525d782609b351d22ab67374434a76a885b1778c4652b25f064L28-R48)
- Added standard JWT claims (`iat`, `jti`) to access and refresh tokens for improved traceability and security.

These changes improve code clarity, maintainability, and security, and provide clearer testing conventions for contributors.