### PR TITLE
Refactor AdminAuth to initialize session maker lazily and update test…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
   detect-changes:
     name: Detect Changed Areas
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     permissions:
       contents: read
     outputs:
@@ -41,6 +42,7 @@ jobs:
   build-backend-image:
     name: Build Backend Docker Image
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.backend == 'true' }}
     permissions:
@@ -61,6 +63,7 @@ jobs:
   python-tests:
     name: Python Tests (with coverage >= 80%)
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.backend == 'true' }}
     permissions:
@@ -100,11 +103,11 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
   frontend-build-and-tests:
-    name: Frontend Build and Tests (allowed to fail)
+    name: Frontend Build and Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.frontend == 'true' }}
-    continue-on-error: true
     permissions:
       contents: read
     steps:
@@ -121,12 +124,30 @@ jobs:
       - name: Lint
         working-directory: frontend
         run: npm run lint
-      - name: Security audit
-        working-directory: frontend
-        run: npm audit --production --audit-level moderate
       - name: Typecheck and build
         working-directory: frontend
         run: npm run build
       - name: Run unit tests (vitest)
         working-directory: frontend
         run: npm run test:run -- --reporter=dot
+
+  frontend-security-audit:
+    name: Frontend Security Audit (optional)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.frontend == 'true' }}
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+      - name: Security audit
+        working-directory: frontend
+        run: npm audit --omit=dev --audit-level moderate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ line-ending = "auto"
 pythonpath = "."
 addopts = ["--import-mode=importlib", "-v"]
 asyncio_mode = "auto"
-testpaths = ["/tests"]
+testpaths = ["tests"]
 markers = [
     "requires_s3: tests that need real S3 object storage operations",
 ]

--- a/src/viewport/admin/auth.py
+++ b/src/viewport/admin/auth.py
@@ -16,7 +16,20 @@ class AdminAuth(AuthenticationBackend):
 
     def __init__(self, secret_key: str):
         super().__init__(secret_key)
-        self._session_maker: async_sessionmaker[AsyncSession] = get_session_maker()
+        self._session_maker: async_sessionmaker[AsyncSession] | None = None
+
+    def _get_session_maker(self) -> async_sessionmaker[AsyncSession]:
+        """Return the admin DB session factory, initializing it lazily.
+
+        ``viewport.main`` constructs this backend at import time so SQLAdmin can
+        be attached to the FastAPI app.  Resolving the sessionmaker there also
+        resolves ``DatabaseSettings`` and creates an engine, which makes import-
+        only tests and tooling depend on ambient database environment variables.
+        Keep database access on the request path instead.
+        """
+        if self._session_maker is None:
+            self._session_maker = get_session_maker()
+        return self._session_maker
 
     async def authenticate(self, request: Request) -> bool:
         """Return True if a user is currently authenticated for the admin."""
@@ -24,7 +37,8 @@ class AdminAuth(AuthenticationBackend):
         if not user_id:
             return False
 
-        async with self._session_maker() as session:
+        session_maker = self._get_session_maker()
+        async with session_maker() as session:
             stmt = select(User.is_admin).where(User.id == user_id)
             is_admin = (await session.execute(stmt)).scalar_one_or_none()
             return bool(is_admin)
@@ -57,7 +71,8 @@ class AdminAuth(AuthenticationBackend):
         if not email or not password:
             return False
 
-        async with self._session_maker() as session:
+        session_maker = self._get_session_maker()
+        async with session_maker() as session:
             stmt = select(User).where(User.email == email)
             user = (await session.execute(stmt)).scalar_one_or_none()
 

--- a/tests/test_main_lifespan.py
+++ b/tests/test_main_lifespan.py
@@ -1,4 +1,5 @@
 import importlib
+import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -15,11 +16,34 @@ def main_module():
     ):
         import viewport.main as imported_main
 
-        yield importlib.reload(imported_main)
+        try:
+            yield importlib.reload(imported_main)
+        finally:
+            # Do not reload outside the patches: a real ``get_engine()`` call would
+            # make this import-only lifespan test depend on ambient DB settings.
+            sys.modules.pop("viewport.main", None)
 
-    import viewport.main as restored_main
 
-    importlib.reload(restored_main)
+def test_import_main_does_not_initialize_admin_db_sessionmaker():
+    with (
+        patch("viewport.logging_config.configure_logging"),
+        patch("viewport.metrics.setup_metrics"),
+        patch("viewport.models.db.get_engine", return_value=MagicMock(name="engine")),
+        patch(
+            "viewport.admin.auth.get_session_maker",
+            side_effect=AssertionError("sessionmaker should be lazy"),
+        ) as mock_get_session_maker,
+        patch("sqladmin.Admin"),
+    ):
+        try:
+            import viewport.main as imported_main
+
+            reloaded_main = importlib.reload(imported_main)
+        finally:
+            sys.modules.pop("viewport.main", None)
+
+    mock_get_session_maker.assert_not_called()
+    assert reloaded_main.authentication_backend._session_maker is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request refactors the admin authentication backend to lazily initialize the database sessionmaker, preventing unnecessary database connections at import time. This change improves testability and avoids requiring database environment variables for import-only tests. Additionally, new tests are added to verify that the sessionmaker is not initialized during module import.

**Lazy Initialization of Database Sessionmaker:**

* Refactored `AdminAuth` in `src/viewport/admin/auth.py` to lazily initialize the `_session_maker` only when needed, instead of at construction time. This avoids resolving database settings and creating a database engine during module import, which improves test isolation and avoids environment variable dependencies.
* Updated all usages of the sessionmaker in `AdminAuth` methods to use the new `_get_session_maker()` method, ensuring the sessionmaker is only created when actually needed. [[1]](diffhunk://#diff-3bb8d24934409064bf1decea4bcc6417a2296878bc8b418bf09acc3bf3dc5791L19-R41) [[2]](diffhunk://#diff-3bb8d24934409064bf1decea4bcc6417a2296878bc8b418bf09acc3bf3dc5791L60-R75)

**Testing Improvements:**

* Added a test in `tests/test_main_lifespan.py` to ensure that importing `viewport.main` does not initialize the admin DB sessionmaker, verifying that the sessionmaker is now truly lazy.
* Improved test hygiene in `tests/test_main_lifespan.py` by cleaning up `sys.modules` after reloading modules, preventing side effects between tests.
* Minor import update in `tests/test_main_lifespan.py` to include `sys` for module cleanup.