### PR TITLE
Refactor GalleryPage sorting, favorites visibility, and tests

### DIFF
--- a/frontend/src/__tests__/pages/GalleryPage.test.tsx
+++ b/frontend/src/__tests__/pages/GalleryPage.test.tsx
@@ -280,7 +280,7 @@ describe('GalleryPage', () => {
       expect(screen.getByText('Gallery #1')).toBeInTheDocument();
     });
 
-    expect(screen.getByRole('heading', { level: 2, name: /Photos\s*3/i })).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: /Gallery photos/i })).toBeInTheDocument();
     expect(screen.getByText('Share Links')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /more gallery actions/i })).toBeInTheDocument();
     expect(screen.getAllByRole('img')).toHaveLength(3);
@@ -380,7 +380,7 @@ describe('GalleryPage', () => {
       render(<GalleryPageWrapper />);
 
       await waitFor(() => {
-        expect(screen.getByRole('heading', { level: 2, name: /Photos\s*3/i })).toBeInTheDocument();
+        expect(screen.getByRole('region', { name: /Gallery photos/i })).toBeInTheDocument();
       });
 
       // Find photo images and their parent buttons
@@ -412,7 +412,7 @@ describe('GalleryPage', () => {
       render(<GalleryPageWrapper />);
 
       await waitFor(() => {
-        expect(screen.getByRole('heading', { level: 2, name: /Photos\s*1/i })).toBeInTheDocument();
+        expect(screen.getByRole('region', { name: /Gallery photos/i })).toBeInTheDocument();
       });
 
       // Open lightbox
@@ -452,7 +452,7 @@ describe('GalleryPage', () => {
       render(<GalleryPageWrapper />);
 
       await waitFor(() => {
-        expect(screen.getByRole('heading', { level: 2, name: /Photos\s*3/i })).toBeInTheDocument();
+        expect(screen.getByRole('region', { name: /Gallery photos/i })).toBeInTheDocument();
       });
 
       // Find the first photo container and get its delete button
@@ -501,7 +501,7 @@ describe('GalleryPage', () => {
       render(<GalleryPageWrapper />);
 
       await waitFor(() => {
-        expect(screen.getByRole('heading', { level: 2, name: /Photos\s*3/i })).toBeInTheDocument();
+        expect(screen.getByRole('region', { name: /Gallery photos/i })).toBeInTheDocument();
       });
 
       const photoImages = screen.getAllByAltText(/photo\d\.jpg/i);
@@ -538,7 +538,7 @@ describe('GalleryPage', () => {
       render(<GalleryPageWrapper />);
 
       await waitFor(() => {
-        expect(screen.getByRole('heading', { level: 2, name: /Photos\s*3/i })).toBeInTheDocument();
+        expect(screen.getByRole('region', { name: /Gallery photos/i })).toBeInTheDocument();
       });
 
       const photoImages = screen.getAllByAltText(/photo\d\.jpg/i);
@@ -580,7 +580,7 @@ describe('GalleryPage', () => {
 
       // Wait for initial load to complete
       await waitFor(() => {
-        expect(screen.getByRole('heading', { level: 2, name: /Photos\s*3/i })).toBeInTheDocument();
+        expect(screen.getByRole('region', { name: /Gallery photos/i })).toBeInTheDocument();
       });
 
       const createLinkButton = screen.getByRole('button', { name: /create new share link/i });

--- a/frontend/src/__tests__/pages/GalleryPage.test.tsx
+++ b/frontend/src/__tests__/pages/GalleryPage.test.tsx
@@ -621,6 +621,16 @@ describe('GalleryPage', () => {
         {
           ...mockShareLink,
           label: 'Client proofing',
+          selection_summary: {
+            is_enabled: true,
+            status: 'in_progress',
+            total_sessions: 1,
+            submitted_sessions: 0,
+            in_progress_sessions: 1,
+            closed_sessions: 0,
+            selected_count: 1,
+            latest_activity_at: '2026-03-31T22:07:00Z',
+          },
         },
       ]);
       vi.mocked(shareLinkService.getGallerySelections).mockResolvedValue([

--- a/frontend/src/components/gallery/GalleryHeader.tsx
+++ b/frontend/src/components/gallery/GalleryHeader.tsx
@@ -223,7 +223,7 @@ export const GalleryHeader = ({
 
   return (
     <div className="relative z-20 -mx-1 sm:-mx-2" data-gallery-header>
-      <section className="sticky top-[4.25rem] z-20 rounded-2xl border border-border/45 bg-surface/96 px-4 py-3 shadow-xs backdrop-blur-md dark:border-border/35 dark:bg-surface-dark/94 sm:top-[4.75rem] sm:px-5">
+      <section className="sticky top-17 z-20 rounded-2xl border border-border/45 bg-surface/96 px-4 py-3 shadow-xs backdrop-blur-md dark:border-border/35 dark:bg-surface-dark/94 sm:top-19 sm:px-5">
         <div className="flex min-h-14 flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
           <div className="min-w-0 flex-1">
             <div className="flex min-w-0 items-center gap-3">

--- a/frontend/src/components/gallery/GalleryHeader.tsx
+++ b/frontend/src/components/gallery/GalleryHeader.tsx
@@ -25,7 +25,7 @@ interface SortOption {
 }
 
 const OPEN_PUBLIC_SORT_EVENT = 'gallery:open-public-sort';
-const DEFAULT_PRIVATE_SORT_STATE = { sortBy: 'uploaded_at', sortOrder: 'desc' } as const;
+const DEFAULT_PRIVATE_SORT_STATE = { sortBy: 'original_filename', sortOrder: 'asc' } as const;
 const DEFAULT_PUBLIC_SORT_STATE = { sortBy: 'original_filename', sortOrder: 'asc' } as const;
 const toSortValue = ({ sortBy, sortOrder }: { sortBy: GalleryPhotoSortBy; sortOrder: SortOrder }) =>
   `${sortBy}:${sortOrder}` as SortOption['value'];

--- a/frontend/src/components/gallery/GalleryPhotoSection.tsx
+++ b/frontend/src/components/gallery/GalleryPhotoSection.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Images, Keyboard, Loader2, MousePointer2, SearchX } from 'lucide-react';
+import { Loader2, SearchX } from 'lucide-react';
 import type { MutableRefObject, RefObject } from 'react';
 import { PaginationControls } from '../PaginationControls';
 import { EmptyGalleryState } from './EmptyGalleryState';
@@ -120,18 +120,11 @@ const GalleryPhotoSectionComponent = ({
     }
   }, [pagination.page, state.activeSearchTerm, shouldShowGridSkeleton]);
 
-  const visibleStart =
-    pagination.total === 0
-      ? 0
-      : Math.min((pagination.page - 1) * pagination.pageSize + 1, pagination.total);
-  const visibleEnd =
-    pagination.total === 0 ? 0 : Math.min(pagination.page * pagination.pageSize, pagination.total);
-
   return (
     <section
       className="px-0 py-0"
       data-photos-section
-      aria-labelledby="private-gallery-photos-heading"
+      aria-label="Gallery photos"
     >
       <div className="mb-4">
         <PhotoUploader
@@ -178,56 +171,6 @@ const GalleryPhotoSectionComponent = ({
             </button>
           </div>
         )}
-      </div>
-
-      <div className="mb-4 rounded-[1.75rem] border border-border/45 bg-surface p-4 shadow-xs dark:border-border/30 dark:bg-surface-dark">
-        <div className="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
-          <div className="flex min-w-0 items-start gap-3">
-            <span className="inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-accent/10 text-accent">
-              <Images className="h-6 w-6" />
-            </span>
-            <div className="min-w-0">
-              <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-accent">
-                Photo grid
-              </p>
-              <h2
-                id="private-gallery-photos-heading"
-                className="font-oswald text-2xl font-bold uppercase tracking-wide text-text"
-              >
-                {state.activeSearchTerm ? 'Filtered photos' : 'Private selects'}
-                <span className="sr-only"> Photos {state.photoUrls.length}</span>
-              </h2>
-              <p className="mt-1 text-sm leading-6 text-muted">
-                Showing {visibleStart}-{visibleEnd} of {pagination.total} photos on page{' '}
-                {pagination.page} of {Math.max(pagination.totalPages, 1)}.
-              </p>
-            </div>
-          </div>
-
-          {pagination.totalPages > 1 ? (
-            <div className="shrink-0 rounded-2xl border border-border/35 bg-surface-1/65 p-2 dark:border-border/25 dark:bg-surface-dark-1/65">
-              <PaginationControls pagination={pagination} isLoading={state.isLoadingPhotos} />
-            </div>
-          ) : null}
-        </div>
-
-        <div className="mt-4 grid gap-2 border-t border-border/30 pt-3 text-xs font-semibold text-muted dark:border-border/25 sm:grid-cols-3">
-          <div className="inline-flex items-center gap-2 rounded-2xl bg-surface-1 px-3 py-2 dark:bg-surface-dark-1">
-            <Keyboard className="h-3.5 w-3.5 text-accent" />
-            Press <kbd className="rounded bg-surface px-1.5 py-0.5 dark:bg-surface-dark-2">
-              /
-            </kbd>{' '}
-            to search
-          </div>
-          <div className="inline-flex items-center gap-2 rounded-2xl bg-surface-1 px-3 py-2 dark:bg-surface-dark-1">
-            <MousePointer2 className="h-3.5 w-3.5 text-accent" />
-            Shift-click selects a range
-          </div>
-          <div className="inline-flex items-center gap-2 rounded-2xl bg-surface-1 px-3 py-2 dark:bg-surface-dark-1">
-            <Images className="h-3.5 w-3.5 text-accent" />
-            Drag files anywhere to upload
-          </div>
-        </div>
       </div>
 
       <PhotoSelectionBar

--- a/frontend/src/components/gallery/GalleryPhotoSection.tsx
+++ b/frontend/src/components/gallery/GalleryPhotoSection.tsx
@@ -121,11 +121,7 @@ const GalleryPhotoSectionComponent = ({
   }, [pagination.page, state.activeSearchTerm, shouldShowGridSkeleton]);
 
   return (
-    <section
-      className="px-0 py-0"
-      data-photos-section
-      aria-label="Gallery photos"
-    >
+    <section className="px-0 py-0" data-photos-section aria-label="Gallery photos">
       <div className="mb-4">
         <PhotoUploader
           ref={photoUploaderRef}

--- a/frontend/src/pages/GalleryPage.tsx
+++ b/frontend/src/pages/GalleryPage.tsx
@@ -41,8 +41,8 @@ import type {
   SortOrder,
 } from '../types';
 
-const DEFAULT_SORT_BY: GalleryPhotoSortBy = 'uploaded_at';
-const DEFAULT_SORT_ORDER: SortOrder = 'desc';
+const DEFAULT_SORT_BY: GalleryPhotoSortBy = 'original_filename';
+const DEFAULT_SORT_ORDER: SortOrder = 'asc';
 const DEFAULT_PUBLIC_SORT_BY: GalleryPhotoSortBy = 'original_filename';
 const DEFAULT_PUBLIC_SORT_ORDER: SortOrder = 'asc';
 const SEARCH_DEBOUNCE_MS = 400;
@@ -498,12 +498,32 @@ export const GalleryPage = () => {
     [photoUrls],
   );
 
-  const favoritesCount = favoritesTabs.length;
   const favoritesSessionCount = favoritesTabs.reduce((sum, tab) => sum + tab.sessionCount, 0);
+  const isFavoritesTabVisible = useMemo(
+    () => shareLinks.some((shareLink) => shareLink.selection_summary?.is_enabled),
+    [shareLinks],
+  );
+  const favoritesSummarySessionCount = useMemo(
+    () =>
+      shareLinks.reduce(
+        (sum, shareLink) => sum + (shareLink.selection_summary?.total_sessions ?? 0),
+        0,
+      ),
+    [shareLinks],
+  );
+  const favoritesTabSessionCount = hasLoadedFavorites
+    ? favoritesSessionCount
+    : favoritesSummarySessionCount;
   const selectedFavoritesTab = useMemo(
     () => favoritesTabs.find((tab) => tab.key === selectedFavoritesTabKey) ?? null,
     [favoritesTabs, selectedFavoritesTabKey],
   );
+
+  useEffect(() => {
+    if (!isFavoritesTabVisible && activeContentTab === 'favorites') {
+      setActiveContentTab('project');
+    }
+  }, [activeContentTab, isFavoritesTabVisible]);
 
   const fetchSelectionRows = useCallback(async () => {
     if (!galleryId) return;
@@ -676,7 +696,12 @@ export const GalleryPage = () => {
     if (activeContentTab !== 'favorites') {
       return;
     }
-    if (shareLinks.length === 0 || hasLoadedFavorites || isLoadingSelectionRows) {
+    if (
+      !isFavoritesTabVisible ||
+      shareLinks.length === 0 ||
+      hasLoadedFavorites ||
+      isLoadingSelectionRows
+    ) {
       return;
     }
     setHasLoadedFavorites(true);
@@ -685,6 +710,7 @@ export const GalleryPage = () => {
     activeContentTab,
     fetchSelectionRows,
     hasLoadedFavorites,
+    isFavoritesTabVisible,
     isLoadingSelectionRows,
     shareLinks.length,
   ]);
@@ -1063,7 +1089,7 @@ export const GalleryPage = () => {
     {
       key: 'favorites' as const,
       tabClassName: contentTabClassName,
-      tab: `Favorites (${hasLoadedFavorites ? favoritesSessionCount : favoritesCount})`,
+      tab: `Favorites (${favoritesTabSessionCount})`,
       panel: (
         <GallerySelectionSessionsPanel
           userTabs={favoritesTabs}
@@ -1158,7 +1184,11 @@ export const GalleryPage = () => {
         />
 
         <AppTabs
-          items={contentTabItems}
+          items={
+            isFavoritesTabVisible
+              ? contentTabItems
+              : contentTabItems.filter((item) => item.key !== 'favorites')
+          }
           selectedKey={activeContentTab}
           onChange={handleSelectContentTab}
           listClassName="flex items-center gap-2 overflow-x-auto px-1 pt-1"

--- a/src/viewport/api/sharelink.py
+++ b/src/viewport/api/sharelink.py
@@ -20,6 +20,7 @@ from viewport.repositories.sharelink_repository import ShareLinkRepository
 from viewport.s3_service import AsyncS3Client
 from viewport.schemas.sharelink import (
     GalleryShareLinkResponse,
+    GalleryShareLinkWithSelectionResponse,
     ScopedShareLinkResponse,
     ShareLinkAnalyticsResponse,
     ShareLinkCreateRequest,
@@ -175,18 +176,29 @@ def _zero_filled_daily_points(
     return points
 
 
-@gallery_router.get("", response_model=list[GalleryShareLinkResponse])
+@gallery_router.get("", response_model=list[GalleryShareLinkWithSelectionResponse])
 async def list_sharelinks(
     gallery_id: UUID,
     repo: GalleryRepository = Depends(get_gallery_repository),
+    selection_repo: SelectionRepository = Depends(get_selection_repository),
     user=Depends(get_current_user),
-) -> list[GalleryShareLinkResponse]:
+) -> list[GalleryShareLinkWithSelectionResponse]:
     gallery = await repo.get_gallery_by_id_and_owner(gallery_id, user.id)
     if not gallery:
         raise HTTPException(status_code=404, detail="Gallery not found")
 
     sharelinks = await repo.get_sharelinks_by_gallery(gallery_id, user.id)
-    return [GalleryShareLinkResponse.model_validate(sharelink) for sharelink in sharelinks]
+    selection_summaries = await selection_repo.get_sharelink_selection_summaries(
+        [sharelink.id for sharelink in sharelinks],
+    )
+    return [
+        GalleryShareLinkWithSelectionResponse.model_validate(sharelink).model_copy(
+            update={
+                "selection_summary": _selection_summary_from_map(selection_summaries, sharelink.id),
+            }
+        )
+        for sharelink in sharelinks
+    ]
 
 
 @gallery_router.post("", response_model=GalleryShareLinkResponse, status_code=status.HTTP_201_CREATED)

--- a/src/viewport/schemas/sharelink.py
+++ b/src/viewport/schemas/sharelink.py
@@ -124,6 +124,10 @@ class ShareLinkSelectionSummaryResponse(BaseModel):
     latest_activity_at: datetime | None
 
 
+class GalleryShareLinkWithSelectionResponse(GalleryShareLinkResponse):
+    selection_summary: ShareLinkSelectionSummaryResponse | None = None
+
+
 class ShareLinkDashboardListItemResponse(ShareLinkDashboardItemResponse):
     latest_activity_at: datetime
     selection_summary: ShareLinkSelectionSummaryResponse | None = None

--- a/tests/test_sharelink_api.py
+++ b/tests/test_sharelink_api.py
@@ -204,6 +204,9 @@ class TestSharelinkAPI:
         )
         assert data[0]["is_active"] is True
         assert "gallery_id" not in data[0]
+        assert data[0]["selection_summary"]["is_enabled"] is False
+        assert data[0]["selection_summary"]["status"] == "not_started"
+        assert data[0]["selection_summary"]["total_sessions"] == 0
 
     def test_list_sharelinks_gallery_not_found(self, authenticated_client: TestClient):
         """Test listing sharelinks for non-existent gallery."""


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the gallery photo section, the gallery page, and the share link API. The main changes include updating accessibility roles and labels in the photo section, changing default photo sorting to filename ascending, enhancing the backend and API to return selection summaries with share links, and updating the UI to conditionally show the "Favorites" tab based on selection summary data.

**Accessibility and UI updates:**

* Changed the gallery photo section's main container from a heading-based region to an explicit `aria-label="Gallery photos"` region for improved accessibility, and updated all related tests to match this change. Removed the prominent photo grid heading and associated UI hints from `GalleryPhotoSection`, simplifying the interface. [[1]](diffhunk://#diff-df12fd8769341e9547fb32a4b91658da041555d30d0ebe2509442a7305379adeL123-R127) [[2]](diffhunk://#diff-df12fd8769341e9547fb32a4b91658da041555d30d0ebe2509442a7305379adeL183-L232) [[3]](diffhunk://#diff-26904174406e3102a894fccb689c009963c0b1ff1f1c4176dcd90ed75c20086dL283-R283) [[4]](diffhunk://#diff-26904174406e3102a894fccb689c009963c0b1ff1f1c4176dcd90ed75c20086dL383-R383) [[5]](diffhunk://#diff-26904174406e3102a894fccb689c009963c0b1ff1f1c4176dcd90ed75c20086dL415-R415) [[6]](diffhunk://#diff-26904174406e3102a894fccb689c009963c0b1ff1f1c4176dcd90ed75c20086dL455-R455) [[7]](diffhunk://#diff-26904174406e3102a894fccb689c009963c0b1ff1f1c4176dcd90ed75c20086dL504-R504) [[8]](diffhunk://#diff-26904174406e3102a894fccb689c009963c0b1ff1f1c4176dcd90ed75c20086dL541-R541) [[9]](diffhunk://#diff-26904174406e3102a894fccb689c009963c0b1ff1f1c4176dcd90ed75c20086dL583-R583)

**Sorting and layout changes:**

* Changed the default sorting for private galleries to `original_filename` ascending (was `uploaded_at` descending) in both the header and main gallery page logic. [[1]](diffhunk://#diff-05ff30b76b32f63fb93bec7407f0e3ae09dbfa89ff34c9d8a0f390fccd042d99L28-R28) [[2]](diffhunk://#diff-1ad38113396286824031d57a90051bb009baaa38e32d54d10cec31eaff15e40fL44-R45)
* Adjusted sticky header positioning in `GalleryHeader` for improved layout consistency.

**Backend/API enhancements:**

* Updated the gallery share link API (`GET /gallery/sharelinks`) to return a new response model including a `selection_summary` object for each share link. This allows the frontend to display selection-related data directly. [[1]](diffhunk://#diff-9dc8455cc347a7593f42f566529d7ea0bd2d39763ba4af3494fed0b898932b4cR23) [[2]](diffhunk://#diff-9dc8455cc347a7593f42f566529d7ea0bd2d39763ba4af3494fed0b898932b4cL178-R201) [[3]](diffhunk://#diff-888840a5eec4fb56d3eccfaa96f4ea2f96e63214a10f204533191e90fc641498R127-R130)
* Added and validated the new `selection_summary` field in backend tests.

**Favorites tab logic improvements:**

* The "Favorites" tab is now only shown if at least one share link has selection enabled. The session count for the tab is computed more robustly from available data, and the UI updates to reflect these counts. [[1]](diffhunk://#diff-1ad38113396286824031d57a90051bb009baaa38e32d54d10cec31eaff15e40fL501-R527) [[2]](diffhunk://#diff-1ad38113396286824031d57a90051bb009baaa38e32d54d10cec31eaff15e40fL679-R704) [[3]](diffhunk://#diff-1ad38113396286824031d57a90051bb009baaa38e32d54d10cec31eaff15e40fR713) [[4]](diffhunk://#diff-1ad38113396286824031d57a90051bb009baaa38e32d54d10cec31eaff15e40fL1066-R1092) [[5]](diffhunk://#diff-1ad38113396286824031d57a90051bb009baaa38e32d54d10cec31eaff15e40fL1161-R1191) [[6]](diffhunk://#diff-26904174406e3102a894fccb689c009963c0b1ff1f1c4176dcd90ed75c20086dR624-R633)

These changes collectively improve accessibility, user experience, and data accuracy for gallery management and share link features.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Share links now include selection summary details.
  - Favorites tab visibility is now driven by share-link selection settings.

* **Changes**
  - Default gallery sorting switched to filename (ascending).
  - Photo count/range and related header controls removed; gallery region labeled "Gallery photos".

* **Tests**
  - Tests updated to assert selection-summary fields and the gallery region labeling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SamuraJey/viewport/pull/146)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->