### PR TITLE
Enhance image upload handling and UI interactions

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,4 +128,5 @@
 
 ## Important rules
 - When making significant changes in the project, update this file to reflect new conventions or architectural patterns.
+- After changes to business logic or user-facing flows, create or update the corresponding documentation in `docs/`. This includes new features, behavioral changes, removed functionality, and architectural decisions that affect how the system behaves from the user's perspective.
 - Documentations must be put in docs/ folder.

--- a/docs/frontend/client-side-image-resize.md
+++ b/docs/frontend/client-side-image-resize.md
@@ -30,18 +30,22 @@ fits within `maxSizeMB` (always 10 MB — the upload limit):
 4. If output ≤ maxSizeMB → raise quality if possible, try again.
 5. Converge to the **maximum quality** that stays within the limit.
 
+Resolution is capped at **4096 px** on the long edge (`maxWidthOrHeight: 4096`) —
+important for photographers with high-megapixel source images.
+
 There is **no user-facing quality slider**. The library auto-optimizes — any
 hand-tuned quality would be overridden by the binary search anyway.
 
 ## Supported MIME types
 
-`SUPPORTED_RESIZE_TYPES` in `imageResize.ts`:
+`SUPPORTED_IMAGE_TYPES` in `constants/upload.ts` (single source of truth, imported by
+`uploadConfirmUtils.ts`, `imageResize.ts`, and `usePhotoUpload.ts`):
+
 ```ts
 ['image/jpeg', 'image/png', 'image/jpg']
 ```
 
-Must stay aligned with `supportedUploadTypes` in `uploadConfirmUtils.ts`.
-Mismatch causes the Resize button to appear but throw on click.
+All three modules now import from the same constant — the lists can no longer diverge.
 
 ## UI: upload confirmation modal
 
@@ -79,7 +83,7 @@ estimate is computed.
 | `FileCard` re-renders during batch | `isResizingBatch` prop disables Framer Motion `layout` animation |
 | `handleResize`/`handleResizeAll` recreations | Wrapped in `useCallback` with correct deps |
 | Stale-closure overwrites in batch loop | Local mutable copy, single `onFilesChange` at end |
-| Bundle size (~25 KB gzipped) | Vite code-splits via dynamic import in modal path |
+| Bundle size (~25 KB gzipped) | Code-split via page-level `React.lazy()` on `GalleryPage` in `App.tsx` |
 
 ## Utility functions
 
@@ -97,7 +101,8 @@ In `frontend/src/components/upload-confirm/uploadConfirmUtils.ts`:
 ```text
 frontend/src/
 ├── lib/
-│   └── imageResize.ts              # resizeImageForUpload
+│   ├── imageResize.ts              # resizeImageForUpload
+│   └── imageThumbnail.ts            # createImageThumbnail (thumbnail previews)
 ├── components/
 │   ├── PhotoUploader.tsx           # Entry: file selection → modal
 │   ├── PhotoUploadConfirmModal.tsx # Modal orchestration

--- a/docs/frontend/client-side-image-resize.md
+++ b/docs/frontend/client-side-image-resize.md
@@ -1,0 +1,111 @@
+# Client-Side Image Resize
+
+Oversized JPEG/PNG files (>10 MB) are resized in the browser before upload using
+`browser-image-compression`. Users never hit a hard rejection — oversized files
+always open the upload confirmation modal where resize controls are available.
+
+## Entry point
+
+`PhotoUploadConfirmModal` (`frontend/src/components/PhotoUploadConfirmModal.tsx`)
+always renders `UploadSelectionContent` when files are selected. The early
+rejection path for oversized files was removed.
+
+## Core module
+
+`frontend/src/lib/imageResize.ts` — `resizeImageForUpload(file, maxBytes?, quality?)`
+
+- Returns the original `File` if already under limit (no unnecessary processing).
+- Uses Web Worker (`useWebWorker: true`) for off-main-thread compression.
+- Preserves file identity: name and type carried through `new File([compressed], name, { type })`.
+- `quality` parameter (0.1–1.0) is optional; passed as `initialQuality` to the library.
+
+## How compression works
+
+`browser-image-compression` uses **binary search** to find the best quality that
+fits within `maxSizeMB` (always 10 MB — the upload limit):
+
+1. Start at `initialQuality` (default 1.0 if not passed).
+2. Compress, check size.
+3. If output > maxSizeMB → lower quality, try again.
+4. If output ≤ maxSizeMB → raise quality if possible, try again.
+5. Converge to the **maximum quality** that stays within the limit.
+
+There is **no user-facing quality slider**. The library auto-optimizes — any
+hand-tuned quality would be overridden by the binary search anyway.
+
+## Supported MIME types
+
+`SUPPORTED_RESIZE_TYPES` in `imageResize.ts`:
+```ts
+['image/jpeg', 'image/png', 'image/jpg']
+```
+
+Must stay aligned with `supportedUploadTypes` in `uploadConfirmUtils.ts`.
+Mismatch causes the Resize button to appear but throw on click.
+
+## UI: upload confirmation modal
+
+All resize UI lives in `frontend/src/components/upload-confirm/`.
+
+### Single resize
+
+Per-file "Resize" button in `FileCard` (only visible when `canResize` is true —
+file is oversized AND has a supported type).
+
+Flow: `handleResize(index)` → `resizeImageForUpload(file)` → `handleReplaceFile(index, resized)`.
+
+Errors shown via `resizeError` banner (auto-clears after 5 seconds).
+
+### Batch resize
+
+"Resize All (N)" button in the issues banner (visible when `hasLargeFiles`).
+
+Flow: `handleResizeAll()` → local mutable copy of `files` → sequential `resizeImageForUpload` per oversized file → `onFilesChange(workingFiles)` once at end.
+
+Batch errors accumulated as `failedCount` and surfaced after the loop:
+`"2 of 5 files failed to resize"`.
+
+### Size display
+
+Oversized files show: `14.2 MB → ≤ 10 MB`
+
+This is an honest upper bound — the library guarantees output ≤10 MB. No fake
+estimate is computed.
+
+## Performance considerations
+
+| Concern | Solution |
+|---|---|
+| `FileCard` re-renders during batch | `isResizingBatch` prop disables Framer Motion `layout` animation |
+| `handleResize`/`handleResizeAll` recreations | Wrapped in `useCallback` with correct deps |
+| Stale-closure overwrites in batch loop | Local mutable copy, single `onFilesChange` at end |
+| Bundle size (~25 KB gzipped) | Vite code-splits via dynamic import in modal path |
+
+## Utility functions
+
+In `frontend/src/components/upload-confirm/uploadConfirmUtils.ts`:
+
+| Function | Purpose |
+|---|---|
+| `isFileTooLarge(file)` | `file.size > MAX_UPLOAD_FILE_SIZE_BYTES` |
+| `isResizableFile(file)` | Too large AND supported type — gates the Resize button |
+| `hasFileUploadError(file)` | Too large OR invalid type |
+| `getFileUploadErrorText(file)` | Human-readable error for the file card |
+
+## Related files
+
+```
+frontend/src/
+├── lib/
+│   └── imageResize.ts              # resizeImageForUpload
+├── components/
+│   ├── PhotoUploader.tsx           # Entry: file selection → modal
+│   ├── PhotoUploadConfirmModal.tsx # Modal orchestration
+│   └── upload-confirm/
+│       ├── UploadSelectionContent.tsx  # Resize UI, handlers, state
+│       └── uploadConfirmUtils.ts       # Size/type checks
+├── hooks/
+│   └── usePhotoUpload.ts           # handleReplaceFile, onFilesChange
+└── constants/
+    └── upload.ts                   # MAX_UPLOAD_FILE_SIZE_BYTES
+```

--- a/docs/frontend/client-side-image-resize.md
+++ b/docs/frontend/client-side-image-resize.md
@@ -94,7 +94,7 @@ In `frontend/src/components/upload-confirm/uploadConfirmUtils.ts`:
 
 ## Related files
 
-```
+```text
 frontend/src/
 ├── lib/
 │   └── imageResize.ts              # resizeImageForUpload

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -719,9 +719,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.128.0.tgz",
-      "integrity": "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -786,9 +786,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.18.tgz",
-      "integrity": "sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -802,9 +802,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.18.tgz",
-      "integrity": "sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -818,9 +818,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.18.tgz",
-      "integrity": "sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -834,9 +834,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.18.tgz",
-      "integrity": "sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -850,9 +850,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.18.tgz",
-      "integrity": "sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -866,9 +866,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.18.tgz",
-      "integrity": "sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
@@ -885,9 +885,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.18.tgz",
-      "integrity": "sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
@@ -904,9 +904,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.18.tgz",
-      "integrity": "sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
@@ -923,9 +923,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.18.tgz",
-      "integrity": "sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
@@ -942,9 +942,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.18.tgz",
-      "integrity": "sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
@@ -961,9 +961,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.18.tgz",
-      "integrity": "sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
@@ -980,9 +980,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.18.tgz",
-      "integrity": "sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -996,9 +996,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.18.tgz",
-      "integrity": "sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
@@ -1014,9 +1014,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.18.tgz",
-      "integrity": "sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -1030,9 +1030,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.18.tgz",
-      "integrity": "sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -3555,16 +3555,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -3871,9 +3871,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4449,10 +4449,20 @@
       "peer": true
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -5350,9 +5360,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -5369,7 +5379,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5646,13 +5656,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.18.tgz",
-      "integrity": "sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.128.0",
-        "@rolldown/pluginutils": "1.0.0-rc.18"
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -5661,27 +5671,27 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.18",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.18",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.18",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.18",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.18",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.18",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.18",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.18",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.18",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.18",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.18",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.18",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.18",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.18",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.18"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.18.tgz",
-      "integrity": "sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "license": "MIT"
     },
     "node_modules/rrweb-cssom": {
@@ -6220,9 +6230,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -6546,16 +6556,16 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.0.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.11.tgz",
-      "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.14",
-        "rolldown": "1.0.0-rc.18",
-        "tinyglobby": "^0.2.16"
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@tailwindcss/vite": "^4.2.2",
         "@types/node": "^24.1.0",
         "axios": "^1.12.0",
+        "browser-image-compression": "^2.0.2",
         "clsx": "^2.1.1",
         "framer-motion": "^12.23.26",
         "lenis": "^1.3.17",
@@ -2445,6 +2446,15 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "license": "MIT",
+      "dependencies": {
+        "uzip": "0.20201231.0"
       }
     },
     "node_modules/browserslist": {
@@ -6528,6 +6538,12 @@
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
       "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
       "license": "(WTFPL OR MIT)"
+    },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "8.0.11",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "@tailwindcss/vite": "^4.2.2",
     "@types/node": "^24.1.0",
     "axios": "^1.12.0",
+    "browser-image-compression": "^2.0.2",
     "clsx": "^2.1.1",
     "framer-motion": "^12.23.26",
     "lenis": "^1.3.17",

--- a/frontend/src/__tests__/components/LazyImage.test.tsx
+++ b/frontend/src/__tests__/components/LazyImage.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { LazyImage } from '../../components/LazyImage';
 
@@ -76,7 +76,9 @@ describe('LazyImage', () => {
 
     expect(screen.queryByRole('img', { name: 'Loaded' })).not.toBeInTheDocument();
 
-    MockIntersectionObserver.instances.forEach((observer) => observer.triggerAll());
+    act(() => {
+      MockIntersectionObserver.instances.forEach((observer) => observer.triggerAll());
+    });
 
     const image = await screen.findByRole('img', { name: 'Loaded' });
     expect(image).toHaveAttribute('loading', 'eager');

--- a/frontend/src/__tests__/components/PhotoUploader.test.tsx
+++ b/frontend/src/__tests__/components/PhotoUploader.test.tsx
@@ -119,33 +119,31 @@ describe('PhotoUploader', () => {
 
     render(<PhotoUploader galleryId="test-gallery" onUploadComplete={mockOnUploadComplete} />);
 
-    const fileInput = screen.getByLabelText(/upload photos/i).querySelector('input[type="file"]');
+    const fileInput = screen.getByLabelText('Choose photos to upload');
 
-    if (fileInput) {
-      await user.upload(fileInput as HTMLInputElement, [largeFile]);
+    await user.upload(fileInput as HTMLInputElement, [largeFile]);
 
-      // Modal should open showing the oversized file
-      await waitFor(() => {
-        expect(screen.getByText('large.jpg')).toBeInTheDocument();
-      });
+    // Modal should open showing the oversized file
+    await waitFor(() => {
+      expect(screen.getByText('large.jpg')).toBeInTheDocument();
+    });
 
-      // Should show warning about oversized files
-      expect(
-        screen.getByText(/All selected files exceed the 10 MB maximum size/),
-      ).toBeInTheDocument();
+    // Should show warning about oversized files
+    expect(
+      screen.getByText(/All selected files exceed the 10 MB maximum size/),
+    ).toBeInTheDocument();
 
-      // Resize All button should be visible for oversized resizable files
-      expect(screen.getByLabelText('Resize all oversized images')).toBeInTheDocument();
+    // Resize All button should be visible for oversized resizable files
+    expect(screen.getByLabelText('Resize all oversized images')).toBeInTheDocument();
 
-      // Upper bound should be shown (library guarantees ≤ 10 MB)
-      expect(screen.getByText(/→ ≤ 10 MB/)).toBeInTheDocument();
+    // Upper bound should be shown (library guarantees ≤ 10 MB)
+    expect(screen.getByText(/→ ≤ 10 MB/)).toBeInTheDocument();
 
-      // Resize button on the file card should still be visible
-      expect(screen.getByLabelText('Resize large.jpg to fit size limit')).toBeInTheDocument();
+    // Resize button on the file card should still be visible
+    expect(screen.getByLabelText('Resize large.jpg to fit size limit')).toBeInTheDocument();
 
-      // Upload button should be disabled
-      expect(screen.getByText('Upload').closest('button')).toBeDisabled();
-    }
+    // Upload button should be disabled
+    expect(screen.getByText('Upload').closest('button')).toBeDisabled();
   });
 
   it('should handle drag and drop events', async () => {

--- a/frontend/src/__tests__/components/PhotoUploader.test.tsx
+++ b/frontend/src/__tests__/components/PhotoUploader.test.tsx
@@ -99,7 +99,9 @@ describe('PhotoUploader', () => {
       // Wait for error message to appear
       await waitFor(() => {
         expect(
-          screen.getByText('Some files have errors and cannot be uploaded'),
+          screen.getByText(
+            'Only JPG and PNG files are supported. Please select valid image files.',
+          ),
         ).toBeInTheDocument();
       });
 
@@ -108,7 +110,7 @@ describe('PhotoUploader', () => {
     }
   });
 
-  it('should reject large files', async () => {
+  it('should open modal with oversized file and show resize option', async () => {
     const user = userEvent.setup();
     // Create a file that's too large (over upload limit)
     const largeFile = new File([new ArrayBuffer(MAX_UPLOAD_FILE_SIZE_BYTES + 1024)], 'large.jpg', {
@@ -122,15 +124,27 @@ describe('PhotoUploader', () => {
     if (fileInput) {
       await user.upload(fileInput as HTMLInputElement, [largeFile]);
 
-      // Wait for error message to appear
+      // Modal should open showing the oversized file
       await waitFor(() => {
-        expect(
-          screen.getByText('Some files have errors and cannot be uploaded'),
-        ).toBeInTheDocument();
+        expect(screen.getByText('large.jpg')).toBeInTheDocument();
       });
 
-      // Modal should not open for oversized files
-      expect(screen.queryByText('Confirm Photo Upload')).not.toBeInTheDocument();
+      // Should show warning about oversized files
+      expect(
+        screen.getByText(/All selected files exceed the 10 MB maximum size/),
+      ).toBeInTheDocument();
+
+      // Resize All button should be visible for oversized resizable files
+      expect(screen.getByLabelText('Resize all oversized images')).toBeInTheDocument();
+
+      // Upper bound should be shown (library guarantees ≤ 10 MB)
+      expect(screen.getByText(/→ ≤ 10 MB/)).toBeInTheDocument();
+
+      // Resize button on the file card should still be visible
+      expect(screen.getByLabelText('Resize large.jpg to fit size limit')).toBeInTheDocument();
+
+      // Upload button should be disabled
+      expect(screen.getByText('Upload').closest('button')).toBeDisabled();
     }
   });
 

--- a/frontend/src/__tests__/components/upload-confirm/uploadConfirmUtils.test.ts
+++ b/frontend/src/__tests__/components/upload-confirm/uploadConfirmUtils.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isResizableFile,
+  isFileTooLarge,
+  estimateResizedSize,
+} from '../../../components/upload-confirm/uploadConfirmUtils';
+import { MAX_UPLOAD_FILE_SIZE_BYTES } from '../../../constants/upload';
+
+function createMockFile(size: number, type: string): File {
+  const blob = new Blob(['x'.repeat(Math.min(size, 1024))], { type });
+  const file = new File([blob], 'test.jpg', { type });
+  Object.defineProperty(file, 'size', { value: size, writable: false });
+  return file;
+}
+
+describe('isResizableFile', () => {
+  it('returns true for oversized JPEG files', () => {
+    const file = createMockFile(MAX_UPLOAD_FILE_SIZE_BYTES + 1024, 'image/jpeg');
+    expect(isResizableFile(file)).toBe(true);
+  });
+
+  it('returns true for oversized PNG files', () => {
+    const file = createMockFile(MAX_UPLOAD_FILE_SIZE_BYTES + 1024, 'image/png');
+    expect(isResizableFile(file)).toBe(true);
+  });
+
+  it('returns true for oversized image/jpg files', () => {
+    const file = createMockFile(MAX_UPLOAD_FILE_SIZE_BYTES + 1024, 'image/jpg');
+    expect(isResizableFile(file)).toBe(true);
+  });
+
+  it('returns false for oversized non-image files', () => {
+    const file = createMockFile(MAX_UPLOAD_FILE_SIZE_BYTES + 1024, 'application/pdf');
+    expect(isResizableFile(file)).toBe(false);
+  });
+
+  it('returns false for small image files (under limit)', () => {
+    const file = createMockFile(1024, 'image/jpeg');
+    expect(isResizableFile(file)).toBe(false);
+  });
+
+  it('returns false for small non-image files', () => {
+    const file = createMockFile(1024, 'application/pdf');
+    expect(isResizableFile(file)).toBe(false);
+  });
+
+  it('returns false for files exactly at the size limit', () => {
+    const file = createMockFile(MAX_UPLOAD_FILE_SIZE_BYTES, 'image/jpeg');
+    expect(isResizableFile(file)).toBe(false);
+  });
+});
+
+describe('isFileTooLarge', () => {
+  it('returns true when file exceeds MAX_UPLOAD_FILE_SIZE_BYTES', () => {
+    const file = createMockFile(MAX_UPLOAD_FILE_SIZE_BYTES + 1, 'image/jpeg');
+    expect(isFileTooLarge(file)).toBe(true);
+  });
+
+  it('returns false when file is under MAX_UPLOAD_FILE_SIZE_BYTES', () => {
+    const file = createMockFile(MAX_UPLOAD_FILE_SIZE_BYTES - 1, 'image/jpeg');
+    expect(isFileTooLarge(file)).toBe(false);
+  });
+});
+
+describe('estimateResizedSize', () => {
+  it('returns correct estimate', () => {
+    expect(estimateResizedSize(10_485_760, 80)).toBe(8_388_608);
+  });
+
+  it('returns 0 for quality 0', () => {
+    expect(estimateResizedSize(1_000_000, 0)).toBe(0);
+  });
+
+  it('returns original size for quality 100', () => {
+    expect(estimateResizedSize(5000, 100)).toBe(5000);
+  });
+
+  it('rounds to nearest integer', () => {
+    expect(estimateResizedSize(1000, 33)).toBe(330);
+  });
+});

--- a/frontend/src/__tests__/components/upload-confirm/uploadConfirmUtils.test.ts
+++ b/frontend/src/__tests__/components/upload-confirm/uploadConfirmUtils.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest';
 import {
   isResizableFile,
   isFileTooLarge,
-  estimateResizedSize,
 } from '../../../components/upload-confirm/uploadConfirmUtils';
 import { MAX_UPLOAD_FILE_SIZE_BYTES } from '../../../constants/upload';
 
@@ -59,23 +58,5 @@ describe('isFileTooLarge', () => {
   it('returns false when file is under MAX_UPLOAD_FILE_SIZE_BYTES', () => {
     const file = createMockFile(MAX_UPLOAD_FILE_SIZE_BYTES - 1, 'image/jpeg');
     expect(isFileTooLarge(file)).toBe(false);
-  });
-});
-
-describe('estimateResizedSize', () => {
-  it('returns correct estimate', () => {
-    expect(estimateResizedSize(10_485_760, 80)).toBe(8_388_608);
-  });
-
-  it('returns 0 for quality 0', () => {
-    expect(estimateResizedSize(1_000_000, 0)).toBe(0);
-  });
-
-  it('returns original size for quality 100', () => {
-    expect(estimateResizedSize(5000, 100)).toBe(5000);
-  });
-
-  it('rounds to nearest integer', () => {
-    expect(estimateResizedSize(1000, 33)).toBe(330);
   });
 });

--- a/frontend/src/__tests__/lib/imageResize.test.ts
+++ b/frontend/src/__tests__/lib/imageResize.test.ts
@@ -72,6 +72,22 @@ describe('resizeImageForUpload', () => {
         maxWidthOrHeight: 4096,
       });
     });
+
+    it('compresses an oversized JPG (image/jpg — nonstandard MIME) and returns a file under the limit', async () => {
+      const file = createMockFile('large.jpg', 15 * 1024 * 1024, 'image/jpg');
+      const compressedFile = createMockFile('large.jpg', 8 * 1024 * 1024, 'image/jpg');
+      mockedImageCompression.mockResolvedValue(compressedFile);
+
+      const result = await resizeImageForUpload(file);
+
+      expect(result).not.toBe(file);
+      expect(result.size).toBeLessThanOrEqual(MAX_UPLOAD_FILE_SIZE_BYTES);
+      expect(mockedImageCompression).toHaveBeenCalledWith(file, {
+        maxSizeMB: 10,
+        useWebWorker: true,
+        maxWidthOrHeight: 4096,
+      });
+    });
   });
 
   describe('file identity preservation', () => {

--- a/frontend/src/__tests__/lib/imageResize.test.ts
+++ b/frontend/src/__tests__/lib/imageResize.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { resizeImageForUpload } from '../../lib/imageResize';
+import imageCompression from 'browser-image-compression';
+import { MAX_UPLOAD_FILE_SIZE_BYTES } from '../../constants/upload';
+
+vi.mock('browser-image-compression');
+
+const mockedImageCompression = vi.mocked(imageCompression);
+
+function createMockFile(name: string, size: number, type: string): File {
+  const blob = new Blob(['x'.repeat(Math.min(size, 1024))], { type });
+  const file = new File([blob], name, { type });
+  // Override size since Blob-based File may not match
+  Object.defineProperty(file, 'size', { value: size, writable: false });
+  return file;
+}
+
+describe('resizeImageForUpload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('files under the size limit', () => {
+    it('returns the original file unchanged when file.size <= maxBytes', async () => {
+      const file = createMockFile('small.jpg', 5 * 1024 * 1024, 'image/jpeg');
+
+      const result = await resizeImageForUpload(file);
+
+      expect(result).toBe(file);
+      expect(mockedImageCompression).not.toHaveBeenCalled();
+    });
+
+    it('returns a non-image file unchanged when under limit', async () => {
+      const file = createMockFile('doc.pdf', 1024, 'application/pdf');
+
+      const result = await resizeImageForUpload(file);
+
+      expect(result).toBe(file);
+      expect(mockedImageCompression).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('oversized image files', () => {
+    it('compresses an oversized JPEG and returns a file under the limit', async () => {
+      const file = createMockFile('large.jpg', 15 * 1024 * 1024, 'image/jpeg');
+      const compressedFile = createMockFile('large.jpg', 8 * 1024 * 1024, 'image/jpeg');
+      mockedImageCompression.mockResolvedValue(compressedFile);
+
+      const result = await resizeImageForUpload(file);
+
+      expect(result).not.toBe(file);
+      expect(result.size).toBeLessThanOrEqual(MAX_UPLOAD_FILE_SIZE_BYTES);
+      expect(mockedImageCompression).toHaveBeenCalledWith(file, {
+        maxSizeMB: 10,
+        useWebWorker: true,
+        maxWidthOrHeight: 4096,
+      });
+    });
+
+    it('compresses an oversized PNG and returns a file under the limit', async () => {
+      const file = createMockFile('large.png', 20 * 1024 * 1024, 'image/png');
+      const compressedFile = createMockFile('large.png', 9 * 1024 * 1024, 'image/png');
+      mockedImageCompression.mockResolvedValue(compressedFile);
+
+      const result = await resizeImageForUpload(file);
+
+      expect(result).not.toBe(file);
+      expect(result.size).toBeLessThanOrEqual(MAX_UPLOAD_FILE_SIZE_BYTES);
+      expect(mockedImageCompression).toHaveBeenCalledWith(file, {
+        maxSizeMB: 10,
+        useWebWorker: true,
+        maxWidthOrHeight: 4096,
+      });
+    });
+  });
+
+  describe('file identity preservation', () => {
+    it('preserves the original file name after compression', async () => {
+      const file = createMockFile('vacation-photo.jpg', 12 * 1024 * 1024, 'image/jpeg');
+      const compressedFile = createMockFile('temp.jpg', 5 * 1024 * 1024, 'image/jpeg');
+      mockedImageCompression.mockResolvedValue(compressedFile);
+
+      const result = await resizeImageForUpload(file);
+
+      expect(result.name).toBe('vacation-photo.jpg');
+    });
+
+    it('preserves the original file type after compression', async () => {
+      const file = createMockFile('photo.jpg', 12 * 1024 * 1024, 'image/jpeg');
+      const compressedFile = createMockFile('photo.jpg', 5 * 1024 * 1024, 'image/jpeg');
+      mockedImageCompression.mockResolvedValue(compressedFile);
+
+      const result = await resizeImageForUpload(file);
+
+      expect(result.type).toBe('image/jpeg');
+    });
+
+    it('falls back to original file type when compressed type is empty', async () => {
+      const file = createMockFile('photo.jpg', 12 * 1024 * 1024, 'image/jpeg');
+      const compressedFile = createMockFile('photo.jpg', 5 * 1024 * 1024, '');
+      mockedImageCompression.mockResolvedValue(compressedFile);
+
+      const result = await resizeImageForUpload(file);
+
+      expect(result.type).toBe('image/jpeg');
+    });
+  });
+
+  describe('unsupported file types', () => {
+    it('throws for oversized non-image files', async () => {
+      const file = createMockFile('doc.pdf', 15 * 1024 * 1024, 'application/pdf');
+
+      await expect(resizeImageForUpload(file)).rejects.toThrow('Cannot resize file type');
+    });
+
+    it('throws for oversized files with unknown MIME type', async () => {
+      const file = createMockFile('binary.bin', 15 * 1024 * 1024, '');
+
+      await expect(resizeImageForUpload(file)).rejects.toThrow('Cannot resize file type');
+    });
+  });
+
+  describe('compression failures', () => {
+    it('throws a user-friendly error when compression fails', async () => {
+      const file = createMockFile('corrupt.jpg', 12 * 1024 * 1024, 'image/jpeg');
+      mockedImageCompression.mockRejectedValue(new Error('Canvas error'));
+
+      await expect(resizeImageForUpload(file)).rejects.toThrow('Failed to resize image');
+    });
+  });
+
+  describe('default maxBytes', () => {
+    it('uses MAX_UPLOAD_FILE_SIZE_BYTES as default target', async () => {
+      const file = createMockFile('photo.jpg', 12 * 1024 * 1024, 'image/jpeg');
+      const compressedFile = createMockFile('photo.jpg', 9 * 1024 * 1024, 'image/jpeg');
+      mockedImageCompression.mockResolvedValue(compressedFile);
+
+      await resizeImageForUpload(file);
+
+      expect(mockedImageCompression).toHaveBeenCalledWith(
+        file,
+        expect.objectContaining({
+          maxSizeMB: MAX_UPLOAD_FILE_SIZE_BYTES / (1024 * 1024),
+        }),
+      );
+    });
+  });
+
+  describe('quality parameter', () => {
+    it('passes initialQuality to imageCompression when quality is provided', async () => {
+      const file = createMockFile('large.jpg', 15 * 1024 * 1024, 'image/jpeg');
+      const compressedFile = createMockFile('large.jpg', 8 * 1024 * 1024, 'image/jpeg');
+      mockedImageCompression.mockResolvedValue(compressedFile);
+
+      await resizeImageForUpload(file, MAX_UPLOAD_FILE_SIZE_BYTES, 0.5);
+
+      expect(mockedImageCompression).toHaveBeenCalledWith(
+        file,
+        expect.objectContaining({
+          maxSizeMB: 10,
+          useWebWorker: true,
+          maxWidthOrHeight: 4096,
+          initialQuality: 0.5,
+        }),
+      );
+    });
+
+    it('does not pass initialQuality when quality is omitted', async () => {
+      const file = createMockFile('large.jpg', 15 * 1024 * 1024, 'image/jpeg');
+      const compressedFile = createMockFile('large.jpg', 8 * 1024 * 1024, 'image/jpeg');
+      mockedImageCompression.mockResolvedValue(compressedFile);
+
+      await resizeImageForUpload(file);
+
+      const callOptions = mockedImageCompression.mock.calls[0][1];
+      expect(callOptions).not.toHaveProperty('initialQuality');
+    });
+  });
+});

--- a/frontend/src/__tests__/lib/imageThumbnail.test.ts
+++ b/frontend/src/__tests__/lib/imageThumbnail.test.ts
@@ -74,5 +74,40 @@ describe('createImageThumbnail', () => {
       result.cleanup();
       expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
     });
+
+    it('falls back to a full-file blob url when canvas.toBlob returns null', async () => {
+      const file = createMockFile('photo.jpg', 1024, 'image/jpeg');
+      const bitmap = createMockBitmap(400, 267);
+      vi.stubGlobal('createImageBitmap', vi.fn().mockResolvedValue(bitmap));
+      const toBlobSpy = vi.spyOn(HTMLCanvasElement.prototype, 'toBlob').mockImplementation((cb) => {
+        cb(null);
+      });
+
+      const result = await createImageThumbnail(file);
+
+      expect(result.url).toBe('blob:mock-url');
+      expect(URL.createObjectURL).toHaveBeenCalledWith(file);
+      result.cleanup();
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+
+      toBlobSpy.mockRestore();
+    });
+
+    it('passes a custom maxDimension through to createImageBitmap', async () => {
+      const file = createMockFile('photo.jpg', 5 * 1024 * 1024, 'image/jpeg');
+      const bitmap = createMockBitmap(200, 133);
+      vi.stubGlobal('createImageBitmap', vi.fn().mockResolvedValue(bitmap));
+
+      const result = await createImageThumbnail(file, 200);
+
+      expect(result.url).toBe('blob:mock-url');
+      expect(createImageBitmap).toHaveBeenCalledWith(file, {
+        resizeWidth: 200,
+        resizeHeight: 200,
+        resizeQuality: 'high',
+        imageOrientation: 'from-image',
+      });
+      result.cleanup();
+    });
   });
 });

--- a/frontend/src/__tests__/lib/imageThumbnail.test.ts
+++ b/frontend/src/__tests__/lib/imageThumbnail.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createImageThumbnail, type ThumbnailResult } from '../../lib/imageThumbnail';
+
+function createMockFile(name: string, size: number, type: string): File {
+  const blob = new Blob(['x'.repeat(Math.min(size, 1024))], { type });
+  const file = new File([blob], name, { type });
+  Object.defineProperty(file, 'size', { value: size, writable: false });
+  return file;
+}
+
+function createMockBitmap(width: number, height: number): ImageBitmap & { close: () => void } {
+  return {
+    width,
+    height,
+    close: vi.fn(),
+    // Minimal stub for other ImageBitmap properties we don't touch
+    colorSpace: 'srgb',
+  } as unknown as ImageBitmap & { close: () => void };
+}
+
+describe('createImageThumbnail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('createImageBitmap', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('non-image files', () => {
+    it('returns a null url and no-op cleanup', async () => {
+      const file = createMockFile('doc.pdf', 1024, 'application/pdf');
+
+      const result = await createImageThumbnail(file);
+
+      expect(result.url).toBeNull();
+      expect(createImageBitmap).not.toHaveBeenCalled();
+      expect(() => result.cleanup()).not.toThrow();
+    });
+  });
+
+  describe('image files', () => {
+    it('creates a thumbnail blob url and a cleanup that revokes it', async () => {
+      const file = createMockFile('photo.jpg', 5 * 1024 * 1024, 'image/jpeg');
+      const bitmap = createMockBitmap(400, 267);
+      vi.stubGlobal('createImageBitmap', vi.fn().mockResolvedValue(bitmap));
+
+      const result: ThumbnailResult = await createImageThumbnail(file);
+
+      expect(result.url).toBe('blob:mock-url');
+      expect(createImageBitmap).toHaveBeenCalledWith(file, {
+        resizeWidth: 400,
+        resizeHeight: 400,
+        resizeQuality: 'high',
+        imageOrientation: 'from-image',
+      });
+      expect(bitmap.close).toHaveBeenCalled();
+      result.cleanup();
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+    });
+
+    it('falls back to a full-file blob url when createImageBitmap rejects', async () => {
+      const file = createMockFile('corrupt.jpg', 1024, 'image/jpeg');
+      vi.stubGlobal(
+        'createImageBitmap',
+        vi.fn().mockRejectedValue(new DOMException('Invalid image')),
+      );
+
+      const result = await createImageThumbnail(file);
+
+      expect(result.url).toBe('blob:mock-url');
+      expect(URL.createObjectURL).toHaveBeenCalledWith(file);
+      result.cleanup();
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+    });
+  });
+});

--- a/frontend/src/__tests__/pages/AccessibilityPage.test.tsx
+++ b/frontend/src/__tests__/pages/AccessibilityPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, describe, expect, it } from 'vitest';
 import { AccessibilityPage } from '../../pages/AccessibilityPage';
@@ -13,12 +13,14 @@ describe('AccessibilityPage', () => {
     });
   });
 
-  it('renders accessibility guidance and low-vision information', () => {
-    render(
-      <MemoryRouter>
-        <AccessibilityPage />
-      </MemoryRouter>,
-    );
+  it('renders accessibility guidance and low-vision information', async () => {
+    await act(async () => {
+      render(
+        <MemoryRouter>
+          <AccessibilityPage />
+        </MemoryRouter>,
+      );
+    });
 
     expect(screen.getByRole('heading', { name: /accessibility in viewport/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: /low-vision mode/i })).toBeInTheDocument();
@@ -27,7 +29,7 @@ describe('AccessibilityPage', () => {
     expect(document.title).toBe('Accessibility · Viewport');
   });
 
-  it('links authenticated users back to the dashboard', () => {
+  it('links authenticated users back to the dashboard', async () => {
     useAuthStore.setState({
       user: {
         id: 'user-1',
@@ -43,11 +45,13 @@ describe('AccessibilityPage', () => {
       isAuthenticated: true,
     });
 
-    render(
-      <MemoryRouter>
-        <AccessibilityPage />
-      </MemoryRouter>,
-    );
+    await act(async () => {
+      render(
+        <MemoryRouter>
+          <AccessibilityPage />
+        </MemoryRouter>,
+      );
+    });
 
     expect(screen.getByRole('link', { name: /back to dashboard/i })).toHaveAttribute(
       'href',

--- a/frontend/src/__tests__/pages/ProjectPage.test.tsx
+++ b/frontend/src/__tests__/pages/ProjectPage.test.tsx
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useState } from 'react';
 import type { ReactNode } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 vi.mock('../../components/ui', async (importOriginal) => {
@@ -402,10 +402,14 @@ describe('ProjectPage', () => {
 
     expect(await screen.findByRole('heading', { name: 'Photos' })).toBeInTheDocument();
 
-    fireEvent.click(screen.getByLabelText('Change project visibility for 3eds'));
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Change project visibility for 3eds'));
+    });
     const visibilityPanel = (await screen.findByText('Project visibility')).parentElement;
     expect(visibilityPanel).not.toBeNull();
-    fireEvent.click(within(visibilityPanel!).getByRole('button', { name: /move earlier/i }));
+    await act(async () => {
+      fireEvent.click(within(visibilityPanel!).getByRole('button', { name: /move earlier/i }));
+    });
 
     expect(projectService.reorderProjectGalleries).toHaveBeenCalledWith('project-1', [
       'gallery-2',

--- a/frontend/src/components/PhotoUploadConfirmModal.tsx
+++ b/frontend/src/components/PhotoUploadConfirmModal.tsx
@@ -43,6 +43,7 @@ export const PhotoUploadConfirmModal = memo(
       hasInvalidTypes,
       renameWarnings,
       handleRemoveFile,
+      handleReplaceFile,
       handleUpload,
       handleRetryFailed,
       cancelUpload,
@@ -195,6 +196,7 @@ export const PhotoUploadConfirmModal = memo(
               renameWarnings={renameWarnings}
               isUploading={isUploading}
               onRemoveFile={handleRemoveFile}
+              handleReplaceFile={handleReplaceFile}
               onFilesChange={onFilesChange}
             />
           )}

--- a/frontend/src/components/PhotoUploader.tsx
+++ b/frontend/src/components/PhotoUploader.tsx
@@ -2,7 +2,7 @@ import { forwardRef, useImperativeHandle, useRef, useState } from 'react';
 import { Upload, ImagePlus } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { PhotoUploadConfirmModal } from './PhotoUploadConfirmModal';
-import { MAX_UPLOAD_FILE_SIZE_BYTES, MAX_UPLOAD_FILE_SIZE_MB } from '../constants/upload';
+import { MAX_UPLOAD_FILE_SIZE_MB } from '../constants/upload';
 import type { PhotoUploadResponse } from '../types';
 
 interface PhotoUploaderProps {
@@ -48,20 +48,9 @@ export const PhotoUploader = forwardRef<PhotoUploaderHandle, PhotoUploaderProps>
       }
 
       setError('');
-      const hasValid = fileArray.some((f) => f.size <= MAX_UPLOAD_FILE_SIZE_BYTES);
-
-      if (hasValid) {
-        setFiles(fileArray);
-        setShowConfirmModal(true);
-        onModalStateChange?.(true);
-      } else {
-        const allLarge = fileArray.every((f) => f.size > MAX_UPLOAD_FILE_SIZE_BYTES);
-        setError(
-          allLarge
-            ? 'All files exceed the 10 MB maximum. Resize and try again.'
-            : 'Some files have errors and cannot be uploaded',
-        );
-      }
+      setFiles(fileArray);
+      setShowConfirmModal(true);
+      onModalStateChange?.(true);
     };
 
     const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {

--- a/frontend/src/components/upload-confirm/UploadSelectionContent.tsx
+++ b/frontend/src/components/upload-confirm/UploadSelectionContent.tsx
@@ -4,6 +4,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { MAX_UPLOAD_FILE_SIZE_BYTES } from '../../constants/upload';
 import { formatFileSize } from '../../lib/utils';
 import { resizeImageForUpload } from '../../lib/imageResize';
+import { createImageThumbnail } from '../../lib/imageThumbnail';
 import { getFileUploadErrorText, hasFileUploadError, isResizableFile } from './uploadConfirmUtils';
 
 interface UploadSelectionContentProps {
@@ -17,9 +18,8 @@ interface UploadSelectionContentProps {
   onFilesChange?: (files: File[]) => void;
   handleReplaceFile: (index: number, newFile: File) => void;
 }
-
 const ThumbSkeleton = () => (
-  <div className="w-full h-full animate-pulse bg-surface-1 dark:bg-surface-dark-2">
+  <div className="absolute inset-0 w-full h-full animate-pulse bg-surface-1 dark:bg-surface-dark-2">
     <div className="w-full h-full bg-linear-to-r from-transparent via-white/10 to-transparent" />
   </div>
 );
@@ -61,6 +61,7 @@ const FileCard = memo(
     const fileErrorText = getFileUploadErrorText(file);
     const [shouldLoad, setShouldLoad] = useState(false);
     const [thumbUrl, setThumbUrl] = useState<string | null>(null);
+    const [thumbLoaded, setThumbLoaded] = useState(false);
     const cardRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
@@ -78,13 +79,25 @@ const FileCard = memo(
     }, []);
 
     useEffect(() => {
-      if (shouldLoad && file.type.startsWith('image/')) {
-        const url = URL.createObjectURL(file);
-        if (url.startsWith('blob:')) {
-          setThumbUrl(url);
+      if (!shouldLoad) return;
+      let cancelled = false;
+      let cleanup: (() => void) | null = null;
+
+      createImageThumbnail(file).then((result) => {
+        if (cancelled) {
+          result.cleanup();
+          return;
         }
-        return () => URL.revokeObjectURL(url);
-      }
+        if (result.url) {
+          setThumbLoaded(false);
+          setThumbUrl(result.url);
+        }
+        cleanup = result.cleanup;
+      });
+      return () => {
+        cancelled = true;
+        cleanup?.();
+      };
     }, [shouldLoad, file]);
 
     return (
@@ -104,18 +117,24 @@ const FileCard = memo(
         <div className="relative aspect-4/3 w-full shrink-0 overflow-hidden bg-surface-1 dark:bg-surface-dark-2 border-b border-border/30">
           {isResizing && <ResizeSpinner />}
 
-          {(!shouldLoad || (shouldLoad && !thumbUrl && file.type.startsWith('image/'))) &&
-            !isResizing && <ThumbSkeleton />}
+          {/* Skeleton — fades out when image loads */}
+          {!thumbLoaded && !isResizing && <ThumbSkeleton />}
+
+          {/* Thumbnail image — mounts at opacity-0, fades in on load */}
           {shouldLoad && thumbUrl && !isResizing ? (
             <img
               src={thumbUrl}
               alt={`Preview of ${file.name}`}
-              className={`w-full h-full object-cover transition-opacity duration-300 ${
-                hasError ? 'opacity-40 saturate-50' : ''
+              onLoad={() => setThumbLoaded(true)}
+              className={`absolute inset-0 w-full h-full object-cover transition-opacity duration-300 ${
+                !thumbLoaded ? 'opacity-0' : hasError ? 'opacity-40 saturate-50' : 'opacity-100'
               }`}
               decoding="async"
             />
-          ) : shouldLoad && !thumbUrl && !file.type.startsWith('image/') && !isResizing ? (
+          ) : null}
+
+          {/* Non-image file fallback */}
+          {shouldLoad && !thumbUrl && !file.type.startsWith('image/') && !isResizing ? (
             <div className="w-full h-full flex items-center justify-center">
               <ImageOff className="w-8 h-8 text-muted/60" />
             </div>

--- a/frontend/src/components/upload-confirm/UploadSelectionContent.tsx
+++ b/frontend/src/components/upload-confirm/UploadSelectionContent.tsx
@@ -344,7 +344,7 @@ export const UploadSelectionContent = ({
     e.stopPropagation();
     setIsDragOver(false);
 
-    if (!onFilesChange) return;
+    if (!onFilesChange || isMutating) return;
 
     const droppedFiles = Array.from(e.dataTransfer.files).filter((file) =>
       file.type.startsWith('image/'),

--- a/frontend/src/components/upload-confirm/UploadSelectionContent.tsx
+++ b/frontend/src/components/upload-confirm/UploadSelectionContent.tsx
@@ -80,6 +80,12 @@ const FileCard = memo(
 
     useEffect(() => {
       if (!shouldLoad) return;
+
+      // Reset thumbnail state for new file — prevents stale thumbnail
+      // from previous file in the same card position.
+      setThumbUrl(null);
+      setThumbLoaded(false);
+
       let cancelled = false;
       let cleanup: (() => void) | null = null;
 
@@ -89,7 +95,6 @@ const FileCard = memo(
           return;
         }
         if (result.url) {
-          setThumbLoaded(false);
           setThumbUrl(result.url);
         }
         cleanup = result.cleanup;

--- a/frontend/src/components/upload-confirm/UploadSelectionContent.tsx
+++ b/frontend/src/components/upload-confirm/UploadSelectionContent.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useRef, useState, useMemo } from 'react';
+import { memo, useCallback, useEffect, useRef, useState, useMemo } from 'react';
 import { AlertTriangle, ImageOff, X, Upload, Images, Loader2, Shrink } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { MAX_UPLOAD_FILE_SIZE_BYTES } from '../../constants/upload';
@@ -222,25 +222,28 @@ export const UploadSelectionContent = ({
     total: number;
   } | null>(null);
 
-  const handleResize = async (index: number) => {
-    const file = files[index];
-    if (!file) return;
+  const handleResize = useCallback(
+    async (index: number) => {
+      const file = files[index];
+      if (!file) return;
 
-    setResizingIndex(index);
-    setResizeError(null);
+      setResizingIndex(index);
+      setResizeError(null);
 
-    try {
-      const resized = await resizeImageForUpload(file);
-      handleReplaceFile(index, resized);
-    } catch (err) {
-      setResizeError(err instanceof Error ? err.message : 'Resize failed');
-      setTimeout(() => setResizeError(null), 5000);
-    } finally {
-      setResizingIndex(null);
-    }
-  };
+      try {
+        const resized = await resizeImageForUpload(file);
+        handleReplaceFile(index, resized);
+      } catch (err) {
+        setResizeError(err instanceof Error ? err.message : 'Resize failed');
+        setTimeout(() => setResizeError(null), 5000);
+      } finally {
+        setResizingIndex(null);
+      }
+    },
+    [files, handleReplaceFile],
+  );
 
-  const handleResizeAll = async () => {
+  const handleResizeAll = useCallback(async () => {
     const oversizedIndices: number[] = [];
     for (let i = 0; i < files.length; i++) {
       if (isResizableFile(files[i])) {
@@ -256,6 +259,7 @@ export const UploadSelectionContent = ({
     // Work on a local mutable copy — avoids intermediate re-renders
     // and the stale-closure overwrite bug from calling handleReplaceFile per iteration.
     const workingFiles = [...files];
+    let failedCount = 0;
     for (let i = 0; i < oversizedIndices.length; i++) {
       const index = oversizedIndices[i];
       if (!workingFiles[index]) continue;
@@ -263,14 +267,21 @@ export const UploadSelectionContent = ({
         workingFiles[index] = await resizeImageForUpload(workingFiles[index]);
       } catch (err) {
         console.error(`Resize failed for file at index ${index}:`, err);
+        failedCount++;
       }
       setResizeAllProgress({ current: i + 1, total: oversizedIndices.length });
     }
 
     onFilesChange?.(workingFiles);
+    if (failedCount > 0) {
+      setResizeError(
+        `${failedCount} of ${oversizedIndices.length} file${failedCount !== 1 ? 's' : ''} failed to resize`,
+      );
+      setTimeout(() => setResizeError(null), 5000);
+    }
     setResizeAllProgress(null);
     setIsResizeAllActive(false);
-  };
+  }, [files, onFilesChange]);
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
@@ -280,6 +291,7 @@ export const UploadSelectionContent = ({
   const handleDragLeave = (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
+    // Only set false if leaving the container, not child elements
     if (!e.currentTarget.contains(e.relatedTarget as Node)) {
       setIsDragOver(false);
     }
@@ -313,6 +325,7 @@ export const UploadSelectionContent = ({
     );
 
     const existingFiles = new Set(files.map((f) => `${f.name}-${f.size}`));
+    // Filter out duplicates based on name and size
     const newFiles = droppedFiles.filter((file) => !existingFiles.has(`${file.name}-${file.size}`));
 
     if (newFiles.length > 0) {

--- a/frontend/src/components/upload-confirm/UploadSelectionContent.tsx
+++ b/frontend/src/components/upload-confirm/UploadSelectionContent.tsx
@@ -25,7 +25,7 @@ const ThumbSkeleton = () => (
 );
 
 const ResizeSpinner = () => (
-  <div className="absolute inset-0 flex items-center justify-center bg-black/40 backdrop-blur-[1px] z-10">
+  <div className="absolute inset-0 flex items-center justify-center bg-black/40 dark:bg-black/60 backdrop-blur-[1px] z-10">
     <div className="flex flex-col items-center gap-2">
       <Loader2 className="w-8 h-8 text-white animate-spin" />
       <span className="text-xs text-white font-semibold">Resizing…</span>
@@ -36,26 +36,26 @@ const ResizeSpinner = () => (
 interface FileCardProps {
   file: File;
   index: number;
-  isUploading: boolean;
   onRemoveFile: (index: number) => void;
   renameWarning?: string;
   isResizing: boolean;
   canResize: boolean;
   onResize: (index: number) => void;
   isResizingBatch: boolean;
+  isMutating: boolean;
 }
 
 const FileCard = memo(
   ({
     file,
     index,
-    isUploading,
     onRemoveFile,
     renameWarning,
     isResizing,
     canResize,
     onResize,
     isResizingBatch,
+    isMutating,
   }: FileCardProps) => {
     const hasError = hasFileUploadError(file);
     const fileErrorText = getFileUploadErrorText(file);
@@ -167,7 +167,7 @@ const FileCard = memo(
                 <button
                   type="button"
                   onClick={() => onResize(index)}
-                  disabled={isUploading || isResizing}
+                  disabled={isMutating || isResizing}
                   className="ml-auto shrink-0 inline-flex items-center gap-1 px-2 py-0.5 rounded-md border border-red-300 dark:border-red-700 bg-white/80 dark:bg-red-900/30 text-red-700 dark:text-red-300 text-xs font-semibold hover:bg-red-100 dark:hover:bg-red-900/50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                   aria-label={`Resize ${file.name} to fit size limit`}
                 >
@@ -192,7 +192,7 @@ const FileCard = memo(
         <button
           type="button"
           onClick={() => onRemoveFile(index)}
-          disabled={isUploading || isResizing}
+          disabled={isMutating || isResizing}
           aria-label={`Remove ${file.name}`}
           className="absolute top-2 right-2 p-1.5 bg-black/40 text-white hover:bg-red-500 hover:text-white rounded-full transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus:outline-hidden backdrop-blur-md"
         >
@@ -240,6 +240,8 @@ export const UploadSelectionContent = ({
     current: number;
     total: number;
   } | null>(null);
+
+  const isMutating = isUploading || resizingIndex !== null || isResizeAllActive;
 
   const handleResize = useCallback(
     async (index: number) => {
@@ -519,7 +521,7 @@ export const UploadSelectionContent = ({
         </div>
       )}
 
-      {hasLargeFiles && (
+      {files.some(isResizableFile) && (
         <div className="flex items-center justify-end p-3 bg-surface-1 dark:bg-surface-dark-2 border border-border/40 rounded-xl">
           {isResizeAllActive && resizeAllProgress ? (
             <div className="flex items-center gap-2 px-3 py-1.5 text-xs font-semibold text-muted">
@@ -583,16 +585,16 @@ export const UploadSelectionContent = ({
               const renameWarning = renameWarnings.find((w) => w.original === file.name);
               return (
                 <FileCard
-                  key={`${file.name}-${file.lastModified}`}
+                  key={`${file.name}-${file.lastModified}-${file.size}`}
                   file={file}
                   index={index}
-                  isUploading={isUploading}
                   onRemoveFile={onRemoveFile}
                   renameWarning={renameWarning?.unique}
                   isResizing={resizingIndex === index}
                   canResize={isResizableFile(file)}
                   onResize={handleResize}
                   isResizingBatch={isResizeAllActive}
+                  isMutating={isMutating}
                 />
               );
             })}

--- a/frontend/src/components/upload-confirm/UploadSelectionContent.tsx
+++ b/frontend/src/components/upload-confirm/UploadSelectionContent.tsx
@@ -537,7 +537,7 @@ export const UploadSelectionContent = ({
             <button
               type="button"
               onClick={handleResizeAll}
-              disabled={isUploading || isResizeAllActive}
+              disabled={isMutating}
               className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-accent/30 bg-accent/10 text-accent text-xs font-semibold hover:bg-accent/20 hover:border-accent/50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               aria-label="Resize all oversized images"
             >

--- a/frontend/src/components/upload-confirm/UploadSelectionContent.tsx
+++ b/frontend/src/components/upload-confirm/UploadSelectionContent.tsx
@@ -1,9 +1,10 @@
 import { memo, useEffect, useRef, useState, useMemo } from 'react';
-import { AlertTriangle, ImageOff, X, Upload, Images } from 'lucide-react';
+import { AlertTriangle, ImageOff, X, Upload, Images, Loader2, Shrink } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { MAX_UPLOAD_FILE_SIZE_BYTES } from '../../constants/upload';
 import { formatFileSize } from '../../lib/utils';
-import { getFileUploadErrorText, hasFileUploadError } from './uploadConfirmUtils';
+import { resizeImageForUpload } from '../../lib/imageResize';
+import { getFileUploadErrorText, hasFileUploadError, isResizableFile } from './uploadConfirmUtils';
 
 interface UploadSelectionContentProps {
   files: File[];
@@ -14,11 +15,21 @@ interface UploadSelectionContentProps {
   isUploading: boolean;
   onRemoveFile: (fileIndex: number) => void;
   onFilesChange?: (files: File[]) => void;
+  handleReplaceFile: (index: number, newFile: File) => void;
 }
 
 const ThumbSkeleton = () => (
   <div className="w-full h-full animate-pulse bg-surface-1 dark:bg-surface-dark-2">
     <div className="w-full h-full bg-linear-to-r from-transparent via-white/10 to-transparent" />
+  </div>
+);
+
+const ResizeSpinner = () => (
+  <div className="absolute inset-0 flex items-center justify-center bg-black/40 backdrop-blur-[1px] z-10">
+    <div className="flex flex-col items-center gap-2">
+      <Loader2 className="w-8 h-8 text-white animate-spin" />
+      <span className="text-xs text-white font-semibold">Resizing…</span>
+    </div>
   </div>
 );
 
@@ -28,10 +39,24 @@ interface FileCardProps {
   isUploading: boolean;
   onRemoveFile: (index: number) => void;
   renameWarning?: string;
+  isResizing: boolean;
+  canResize: boolean;
+  onResize: (index: number) => void;
+  isResizingBatch: boolean;
 }
 
 const FileCard = memo(
-  ({ file, index, isUploading, onRemoveFile, renameWarning }: FileCardProps) => {
+  ({
+    file,
+    index,
+    isUploading,
+    onRemoveFile,
+    renameWarning,
+    isResizing,
+    canResize,
+    onResize,
+    isResizingBatch,
+  }: FileCardProps) => {
     const hasError = hasFileUploadError(file);
     const fileErrorText = getFileUploadErrorText(file);
     const [shouldLoad, setShouldLoad] = useState(false);
@@ -55,7 +80,6 @@ const FileCard = memo(
     useEffect(() => {
       if (shouldLoad && file.type.startsWith('image/')) {
         const url = URL.createObjectURL(file);
-        // Validate that the URL is a safe blob URL
         if (url.startsWith('blob:')) {
           setThumbUrl(url);
         }
@@ -65,7 +89,7 @@ const FileCard = memo(
 
     return (
       <motion.div
-        layout
+        layout={!isResizingBatch}
         initial={{ opacity: 0, scale: 0.8 }}
         animate={{ opacity: 1, scale: 1 }}
         exit={{ opacity: 0, scale: 0.8 }}
@@ -78,10 +102,11 @@ const FileCard = memo(
         }`}
       >
         <div className="relative aspect-4/3 w-full shrink-0 overflow-hidden bg-surface-1 dark:bg-surface-dark-2 border-b border-border/30">
-          {(!shouldLoad || (shouldLoad && !thumbUrl && file.type.startsWith('image/'))) && (
-            <ThumbSkeleton />
-          )}
-          {shouldLoad && thumbUrl ? (
+          {isResizing && <ResizeSpinner />}
+
+          {(!shouldLoad || (shouldLoad && !thumbUrl && file.type.startsWith('image/'))) &&
+            !isResizing && <ThumbSkeleton />}
+          {shouldLoad && thumbUrl && !isResizing ? (
             <img
               src={thumbUrl}
               alt={`Preview of ${file.name}`}
@@ -90,13 +115,13 @@ const FileCard = memo(
               }`}
               decoding="async"
             />
-          ) : shouldLoad && !thumbUrl && !file.type.startsWith('image/') ? (
+          ) : shouldLoad && !thumbUrl && !file.type.startsWith('image/') && !isResizing ? (
             <div className="w-full h-full flex items-center justify-center">
               <ImageOff className="w-8 h-8 text-muted/60" />
             </div>
           ) : null}
 
-          {hasError && (
+          {hasError && !isResizing && (
             <div className="absolute inset-0 flex items-center justify-center bg-red-900/10 backdrop-blur-[2px]">
               <AlertTriangle className="w-8 h-8 text-red-500 drop-shadow-md" />
             </div>
@@ -107,12 +132,30 @@ const FileCard = memo(
           <p className="truncate text-sm font-medium text-text" title={file.name}>
             {file.name}
           </p>
-          <span className="text-xs text-muted font-medium mt-0.5">{formatFileSize(file.size)}</span>
+          <span className="text-xs text-muted font-medium mt-0.5">
+            {isResizing
+              ? 'Resizing…'
+              : canResize
+                ? `${formatFileSize(file.size)} → ≤ 10 MB`
+                : formatFileSize(file.size)}
+          </span>
 
           {hasError && fileErrorText && (
             <div className="mt-2 text-xs text-red-600 dark:text-red-400 font-semibold flex items-start gap-1">
               <AlertTriangle className="w-3.5 h-3.5 shrink-0 mt-0.5" />
               <span>Won't upload: {fileErrorText}</span>
+              {canResize && (
+                <button
+                  type="button"
+                  onClick={() => onResize(index)}
+                  disabled={isUploading || isResizing}
+                  className="ml-auto shrink-0 inline-flex items-center gap-1 px-2 py-0.5 rounded-md border border-red-300 dark:border-red-700 bg-white/80 dark:bg-red-900/30 text-red-700 dark:text-red-300 text-xs font-semibold hover:bg-red-100 dark:hover:bg-red-900/50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  aria-label={`Resize ${file.name} to fit size limit`}
+                >
+                  <Shrink className="w-3 h-3" />
+                  Resize
+                </button>
+              )}
             </div>
           )}
 
@@ -130,7 +173,7 @@ const FileCard = memo(
         <button
           type="button"
           onClick={() => onRemoveFile(index)}
-          disabled={isUploading}
+          disabled={isUploading || isResizing}
           aria-label={`Remove ${file.name}`}
           className="absolute top-2 right-2 p-1.5 bg-black/40 text-white hover:bg-red-500 hover:text-white rounded-full transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus:outline-hidden backdrop-blur-md"
         >
@@ -153,6 +196,7 @@ export const UploadSelectionContent = ({
   isUploading,
   onRemoveFile,
   onFilesChange,
+  handleReplaceFile,
 }: UploadSelectionContentProps) => {
   const readyFilesCount = files.filter((file) => !hasFileUploadError(file)).length;
   const hasIssues = hasLargeFiles || hasInvalidTypes || renameWarnings.length > 0;
@@ -167,6 +211,66 @@ export const UploadSelectionContent = ({
   const observerRef = useRef<IntersectionObserver | null>(null);
   const loadMoreRef = useRef<HTMLDivElement>(null);
 
+  // Resize state
+  const [resizingIndex, setResizingIndex] = useState<number | null>(null);
+  const [resizeError, setResizeError] = useState<string | null>(null);
+
+  // Batch resize state
+  const [isResizeAllActive, setIsResizeAllActive] = useState(false);
+  const [resizeAllProgress, setResizeAllProgress] = useState<{
+    current: number;
+    total: number;
+  } | null>(null);
+
+  const handleResize = async (index: number) => {
+    const file = files[index];
+    if (!file) return;
+
+    setResizingIndex(index);
+    setResizeError(null);
+
+    try {
+      const resized = await resizeImageForUpload(file);
+      handleReplaceFile(index, resized);
+    } catch (err) {
+      setResizeError(err instanceof Error ? err.message : 'Resize failed');
+      setTimeout(() => setResizeError(null), 5000);
+    } finally {
+      setResizingIndex(null);
+    }
+  };
+
+  const handleResizeAll = async () => {
+    const oversizedIndices: number[] = [];
+    for (let i = 0; i < files.length; i++) {
+      if (isResizableFile(files[i])) {
+        oversizedIndices.push(i);
+      }
+    }
+    if (oversizedIndices.length === 0) return;
+
+    setIsResizeAllActive(true);
+    setResizeAllProgress({ current: 0, total: oversizedIndices.length });
+    setResizeError(null);
+
+    // Work on a local mutable copy — avoids intermediate re-renders
+    // and the stale-closure overwrite bug from calling handleReplaceFile per iteration.
+    const workingFiles = [...files];
+    for (let i = 0; i < oversizedIndices.length; i++) {
+      const index = oversizedIndices[i];
+      if (!workingFiles[index]) continue;
+      try {
+        workingFiles[index] = await resizeImageForUpload(workingFiles[index]);
+      } catch (err) {
+        console.error(`Resize failed for file at index ${index}:`, err);
+      }
+      setResizeAllProgress({ current: i + 1, total: oversizedIndices.length });
+    }
+
+    onFilesChange?.(workingFiles);
+    setResizeAllProgress(null);
+    setIsResizeAllActive(false);
+  };
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
@@ -176,7 +280,6 @@ export const UploadSelectionContent = ({
   const handleDragLeave = (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    // Only set false if leaving the container, not child elements
     if (!e.currentTarget.contains(e.relatedTarget as Node)) {
       setIsDragOver(false);
     }
@@ -189,7 +292,6 @@ export const UploadSelectionContent = ({
         onFilesChange([...files, ...newFiles]);
       }
     }
-    // Reset input
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
     }
@@ -210,7 +312,6 @@ export const UploadSelectionContent = ({
       file.type.startsWith('image/'),
     );
 
-    // Filter out duplicates based on name and size
     const existingFiles = new Set(files.map((f) => `${f.name}-${f.size}`));
     const newFiles = droppedFiles.filter((file) => !existingFiles.has(`${file.name}-${file.size}`));
 
@@ -243,7 +344,6 @@ export const UploadSelectionContent = ({
 
   const visibleFiles = useMemo(() => files.slice(0, visibleCount), [files, visibleCount]);
 
-  // Empty state when no files
   if (files.length === 0) {
     return (
       <div
@@ -294,7 +394,6 @@ export const UploadSelectionContent = ({
           </button>
         </div>
 
-        {/* Hidden file input */}
         <input
           ref={fileInputRef}
           type="file"
@@ -325,6 +424,15 @@ export const UploadSelectionContent = ({
           )}
         </div>
       </div>
+
+      {resizeError && (
+        <div className="p-3 bg-red-50/70 dark:bg-red-500/10 border border-red-200/70 dark:border-red-500/20 rounded-xl text-sm">
+          <div className="flex items-start gap-2">
+            <AlertTriangle className="w-4 h-4 shrink-0 text-red-600 dark:text-red-400 mt-0.5" />
+            <p className="text-red-800 dark:text-red-300 font-medium">{resizeError}</p>
+          </div>
+        </div>
+      )}
 
       {readyFilesCount === 0 && files.length > 0 && (
         <div className="p-4 bg-red-50/70 dark:bg-red-500/10 border border-red-200/70 dark:border-red-500/20 rounded-2xl shadow-xs text-sm">
@@ -379,6 +487,28 @@ export const UploadSelectionContent = ({
         </div>
       )}
 
+      {hasLargeFiles && (
+        <div className="flex items-center justify-end p-3 bg-surface-1 dark:bg-surface-dark-2 border border-border/40 rounded-xl">
+          {isResizeAllActive && resizeAllProgress ? (
+            <div className="flex items-center gap-2 px-3 py-1.5 text-xs font-semibold text-muted">
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+              Resizing {resizeAllProgress.current} of {resizeAllProgress.total}…
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={handleResizeAll}
+              disabled={isUploading || isResizeAllActive}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-accent/30 bg-accent/10 text-accent text-xs font-semibold hover:bg-accent/20 hover:border-accent/50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              aria-label="Resize all oversized images"
+            >
+              <Shrink className="w-3.5 h-3.5" />
+              Resize All ({files.filter((f) => isResizableFile(f)).length} files)
+            </button>
+          )}
+        </div>
+      )}
+
       <div
         className={`relative rounded-2xl border-2 border-dashed transition-all duration-200 ${
           isDragOver
@@ -421,12 +551,16 @@ export const UploadSelectionContent = ({
               const renameWarning = renameWarnings.find((w) => w.original === file.name);
               return (
                 <FileCard
-                  key={`${file.name}-${file.size}-${file.lastModified}`}
+                  key={`${file.name}-${file.lastModified}`}
                   file={file}
                   index={index}
                   isUploading={isUploading}
                   onRemoveFile={onRemoveFile}
                   renameWarning={renameWarning?.unique}
+                  isResizing={resizingIndex === index}
+                  canResize={isResizableFile(file)}
+                  onResize={handleResize}
+                  isResizingBatch={isResizeAllActive}
                 />
               );
             })}
@@ -436,7 +570,6 @@ export const UploadSelectionContent = ({
         {visibleCount < files.length && <div ref={loadMoreRef} className="h-4 w-full" />}
       </div>
 
-      {/* Hidden file input */}
       <input
         ref={fileInputRef}
         type="file"

--- a/frontend/src/components/upload-confirm/uploadConfirmUtils.ts
+++ b/frontend/src/components/upload-confirm/uploadConfirmUtils.ts
@@ -1,6 +1,10 @@
-import { MAX_UPLOAD_FILE_SIZE_BYTES, MAX_UPLOAD_FILE_SIZE_MB } from '../../constants/upload';
+import {
+  MAX_UPLOAD_FILE_SIZE_BYTES,
+  MAX_UPLOAD_FILE_SIZE_MB,
+  SUPPORTED_IMAGE_TYPES,
+} from '../../constants/upload';
 
-export const supportedUploadTypes = ['image/jpeg', 'image/png', 'image/jpg'];
+const supportedUploadTypes = SUPPORTED_IMAGE_TYPES;
 
 export const isFileTooLarge = (file: File): boolean => file.size > MAX_UPLOAD_FILE_SIZE_BYTES;
 

--- a/frontend/src/components/upload-confirm/uploadConfirmUtils.ts
+++ b/frontend/src/components/upload-confirm/uploadConfirmUtils.ts
@@ -33,11 +33,3 @@ export const getFileUploadErrorText = (file: File) => {
 
   return null;
 };
-
-/**
- * Simple linear heuristic for estimated compressed size.
- * The actual output from browser-image-compression is always ≤ maxSizeMB
- * regardless of quality; this estimate is an approximate guide for the UI.
- */
-export const estimateResizedSize = (originalBytes: number, qualityPercent: number): number =>
-  Math.round(originalBytes * (qualityPercent / 100));

--- a/frontend/src/components/upload-confirm/uploadConfirmUtils.ts
+++ b/frontend/src/components/upload-confirm/uploadConfirmUtils.ts
@@ -1,10 +1,17 @@
 import { MAX_UPLOAD_FILE_SIZE_BYTES, MAX_UPLOAD_FILE_SIZE_MB } from '../../constants/upload';
 
-const supportedUploadTypes = ['image/jpeg', 'image/png', 'image/jpg'];
+export const supportedUploadTypes = ['image/jpeg', 'image/png', 'image/jpg'];
 
-const isFileTooLarge = (file: File) => file.size > MAX_UPLOAD_FILE_SIZE_BYTES;
+export const isFileTooLarge = (file: File): boolean => file.size > MAX_UPLOAD_FILE_SIZE_BYTES;
 
-const isFileTypeInvalid = (file: File) => !supportedUploadTypes.includes(file.type);
+export const isFileTypeInvalid = (file: File): boolean => !supportedUploadTypes.includes(file.type);
+
+/**
+ * Returns true when the file can be resized: it is too large AND has a supported
+ * image type (JPEG or PNG). Only resizable files get the Resize button in the UI.
+ */
+export const isResizableFile = (file: File): boolean =>
+  isFileTooLarge(file) && supportedUploadTypes.includes(file.type);
 
 export const hasFileUploadError = (file: File) => isFileTooLarge(file) || isFileTypeInvalid(file);
 
@@ -26,3 +33,11 @@ export const getFileUploadErrorText = (file: File) => {
 
   return null;
 };
+
+/**
+ * Simple linear heuristic for estimated compressed size.
+ * The actual output from browser-image-compression is always ≤ maxSizeMB
+ * regardless of quality; this estimate is an approximate guide for the UI.
+ */
+export const estimateResizedSize = (originalBytes: number, qualityPercent: number): number =>
+  Math.round(originalBytes * (qualityPercent / 100));

--- a/frontend/src/constants/upload.ts
+++ b/frontend/src/constants/upload.ts
@@ -1,2 +1,3 @@
 export const MAX_UPLOAD_FILE_SIZE_MB = 10;
 export const MAX_UPLOAD_FILE_SIZE_BYTES = MAX_UPLOAD_FILE_SIZE_MB * 1024 * 1024;
+export const SUPPORTED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/jpg'];

--- a/frontend/src/hooks/usePhotoUpload.ts
+++ b/frontend/src/hooks/usePhotoUpload.ts
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback, useMemo } from 'react';
 import { photoService } from '../services/photoService';
-import { MAX_UPLOAD_FILE_SIZE_BYTES } from '../constants/upload';
+import { MAX_UPLOAD_FILE_SIZE_BYTES, SUPPORTED_IMAGE_TYPES } from '../constants/upload';
 import { getSafeNameAndExtension } from '../lib/filenameUtils';
 import type {
   PhotoUploadResponse,
@@ -20,7 +20,7 @@ export interface UploadProgress {
   failedCount?: number;
 }
 
-const SUPPORTED_TYPES = ['image/jpeg', 'image/png', 'image/jpg'];
+const SUPPORTED_TYPES = SUPPORTED_IMAGE_TYPES;
 
 export const usePhotoUpload = (
   galleryId: string,

--- a/frontend/src/hooks/usePhotoUpload.ts
+++ b/frontend/src/hooks/usePhotoUpload.ts
@@ -88,6 +88,15 @@ export const usePhotoUpload = (
     [files, onFilesChange],
   );
 
+  /** Replace a file at the given index with a new file (e.g. after resize). */
+  const handleReplaceFile = useCallback(
+    (index: number, newFile: File) => {
+      const updatedFiles = [...files.slice(0, index), newFile, ...files.slice(index + 1)];
+      onFilesChange?.(updatedFiles);
+    },
+    [files, onFilesChange],
+  );
+
   const handleUpload = useCallback(async () => {
     if (!hasValidFiles) return;
     setIsUploading(true);
@@ -268,6 +277,7 @@ export const usePhotoUpload = (
     hasInvalidTypes,
     renameWarnings,
     handleRemoveFile,
+    handleReplaceFile,
     handleUpload,
     handleRetryFailed,
     cancelUpload,

--- a/frontend/src/lib/imageResize.ts
+++ b/frontend/src/lib/imageResize.ts
@@ -1,7 +1,7 @@
-import imageCompression from 'browser-image-compression';
+import imageCompression, { type Options } from 'browser-image-compression';
 import { MAX_UPLOAD_FILE_SIZE_BYTES } from '../constants/upload';
 
-const SUPPORTED_RESIZE_TYPES = ['image/jpeg', 'image/png'];
+const SUPPORTED_RESIZE_TYPES = ['image/jpeg', 'image/png', 'image/jpg'];
 
 /**
  * Resizes an image file to fit within the specified byte limit.
@@ -31,7 +31,7 @@ export async function resizeImageForUpload(
   }
 
   try {
-    const options: Record<string, unknown> = {
+    const options: Options = {
       maxSizeMB: maxBytes / (1024 * 1024),
       useWebWorker: true,
       maxWidthOrHeight: 4096,

--- a/frontend/src/lib/imageResize.ts
+++ b/frontend/src/lib/imageResize.ts
@@ -1,7 +1,7 @@
 import imageCompression, { type Options } from 'browser-image-compression';
-import { MAX_UPLOAD_FILE_SIZE_BYTES } from '../constants/upload';
+import { MAX_UPLOAD_FILE_SIZE_BYTES, SUPPORTED_IMAGE_TYPES } from '../constants/upload';
 
-const SUPPORTED_RESIZE_TYPES = ['image/jpeg', 'image/png', 'image/jpg'];
+const SUPPORTED_RESIZE_TYPES = SUPPORTED_IMAGE_TYPES;
 
 /**
  * Resizes an image file to fit within the specified byte limit.

--- a/frontend/src/lib/imageResize.ts
+++ b/frontend/src/lib/imageResize.ts
@@ -1,0 +1,53 @@
+import imageCompression from 'browser-image-compression';
+import { MAX_UPLOAD_FILE_SIZE_BYTES } from '../constants/upload';
+
+const SUPPORTED_RESIZE_TYPES = ['image/jpeg', 'image/png'];
+
+/**
+ * Resizes an image file to fit within the specified byte limit.
+ * Uses browser-image-compression with Web Worker for off-main-thread processing.
+ *
+ * Bundle note: browser-image-compression is ~25KB gzipped. Offsetting factors:
+ * - Only loaded with the upload modal code path (Vite code splitting)
+ * - Web Worker offloads Canvas processing from the main thread
+ *
+ * @param file - The image file to resize
+ * @param maxBytes - Target maximum size in bytes (default: MAX_UPLOAD_FILE_SIZE_BYTES)
+ * @param quality - Optional initial quality (0.1–1.0). Lower = more compression, faster resize.
+ * @returns A Promise resolving to the resized File, or the original if already under limit
+ * @throws Error if file type is unsupported for resize or compression fails
+ */
+export async function resizeImageForUpload(
+  file: File,
+  maxBytes: number = MAX_UPLOAD_FILE_SIZE_BYTES,
+  quality?: number,
+): Promise<File> {
+  // Already under limit — no resize needed (includes non-image files that happen to be under limit)
+  if (file.size <= maxBytes) return file;
+
+  // Cannot resize non-image files
+  if (!SUPPORTED_RESIZE_TYPES.includes(file.type)) {
+    throw new Error(`Cannot resize file type: ${file.type || 'unknown'}`);
+  }
+
+  try {
+    const options: Record<string, unknown> = {
+      maxSizeMB: maxBytes / (1024 * 1024),
+      useWebWorker: true,
+      maxWidthOrHeight: 4096,
+    };
+    if (quality !== undefined) {
+      options.initialQuality = quality;
+    }
+    const compressed = await imageCompression(file, options);
+
+    // Guard: ensure the result retains file identity
+    return new File([compressed], file.name, {
+      type: compressed.type || file.type,
+    });
+  } catch (err) {
+    throw new Error(
+      `Failed to resize image: ${err instanceof Error ? err.message : 'Unknown error'}`,
+    );
+  }
+}

--- a/frontend/src/lib/imageThumbnail.ts
+++ b/frontend/src/lib/imageThumbnail.ts
@@ -1,0 +1,62 @@
+export interface ThumbnailResult {
+  url: string | null;
+  cleanup: () => void;
+}
+
+const DEFAULT_MAX_DIMENSION = 400;
+
+/**
+ * Create a small thumbnail preview for an image file without decoding the full
+ * resolution pixel buffer. Uses createImageBitmap with resize options so the
+ * browser decodes directly to thumbnail dimensions.
+ *
+ * Returns a blob: URL and a cleanup function. For non-image files the URL is
+ * null and cleanup is a no-op. On failure (unsupported browser, corrupt file,
+ * etc.) falls back to URL.createObjectURL(file) so previews still work.
+ */
+export async function createImageThumbnail(
+  file: File,
+  maxDimension: number = DEFAULT_MAX_DIMENSION,
+): Promise<ThumbnailResult> {
+  if (!file.type.startsWith('image/')) {
+    return { url: null, cleanup: () => {} };
+  }
+
+  let fallbackUrl: string | null = null;
+
+  try {
+    const bitmap = await createImageBitmap(file, {
+      resizeWidth: maxDimension,
+      resizeHeight: maxDimension,
+      resizeQuality: 'high',
+      imageOrientation: 'from-image',
+    });
+
+    const canvas = document.createElement('canvas');
+    canvas.width = bitmap.width;
+    canvas.height = bitmap.height;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      bitmap.close();
+      throw new Error('Could not get 2d canvas context');
+    }
+
+    ctx.drawImage(bitmap, 0, 0);
+    bitmap.close();
+
+    const blob = await new Promise<Blob | null>((resolve) => {
+      canvas.toBlob(resolve, 'image/jpeg', 0.85);
+    });
+
+    if (!blob) {
+      throw new Error('Canvas toBlob returned null');
+    }
+
+    const url = URL.createObjectURL(blob);
+    return { url, cleanup: () => URL.revokeObjectURL(url) };
+  } catch {
+    fallbackUrl = URL.createObjectURL(file);
+    return { url: fallbackUrl, cleanup: () => URL.revokeObjectURL(fallbackUrl!) };
+  }
+}


### PR DESCRIPTION
This pull request introduces robust client-side image resizing for oversized uploads, ensuring a smoother user experience when uploading large JPEG or PNG files. Instead of rejecting oversized files (>10 MB), the upload confirmation modal now allows users to resize images directly in the browser, leveraging the `browser-image-compression` library. The implementation includes clear UI feedback, batch and per-file resize controls, and comprehensive tests for both utility logic and the core resizing module.

The most important changes are:

**Client-side image resizing feature:**

* Added `resizeImageForUpload` in `frontend/src/lib/imageResize.ts` to compress oversized JPEG/PNG files in the browser using `browser-image-compression`, preserving file name/type and using a Web Worker for performance.
* Updated the upload confirmation modal (`PhotoUploadConfirmModal` and `UploadSelectionContent`) to always show oversized files and provide per-file and batch resize options instead of rejecting them. UI now displays accurate size bounds and disables upload until files are compliant. [[1]](diffhunk://#diff-75f11ae46078b898f79f4d857e16aed90800051ef8d15296ebec025052fae40dR1-R111) [[2]](diffhunk://#diff-5264697beed20b8ee226ebd33f496164b54ea9ff26519b27b1fc4f4fc1975c3fL1-R7) [[3]](diffhunk://#diff-83dedddf8ccb0dd6dd71832b369fb26185f300340ac0e3b674aa3d9d51571d20R46) [[4]](diffhunk://#diff-83dedddf8ccb0dd6dd71832b369fb26185f300340ac0e3b674aa3d9d51571d20R199) [[5]](diffhunk://#diff-d716b602d9ff3f5a6ae68e00f6b97eb97174e49a4529c1f92bed8c32538d186fL5-R5) [[6]](diffhunk://#diff-d716b602d9ff3f5a6ae68e00f6b97eb97174e49a4529c1f92bed8c32538d186fL51-L64)

**Testing and validation:**

* Added comprehensive unit tests for the resizing logic (`resizeImageForUpload`) and utility functions (`isResizableFile`, `isFileTooLarge`) to ensure correct handling of supported types, error cases, and file identity preservation. [[1]](diffhunk://#diff-51e3c8029168787b6b08d8c8793358c4e8bf2c2c608cb439f1cf2d0a8a3477afR1-R179) [[2]](diffhunk://#diff-e9d0f681f93f1cdb9b2d8fe239351ac941f1af168d645ebded48f81108b8f7cbR1-R62)
* Updated existing tests for the uploader to reflect the new flow: oversized files now open the modal with resize options instead of showing an error. [[1]](diffhunk://#diff-ab1d698d3a766917a4371f06bf28a735f71ea0047c7df1c72186e277756a8661L102-R104) [[2]](diffhunk://#diff-ab1d698d3a766917a4371f06bf28a735f71ea0047c7df1c72186e277756a8661L111-R113) [[3]](diffhunk://#diff-ab1d698d3a766917a4371f06bf28a735f71ea0047c7df1c72186e277756a8661L125-R147)

**Documentation and developer guidance:**

* Added detailed documentation in `docs/frontend/client-side-image-resize.md`, covering entry points, supported types, UX, performance considerations, and related files.
* Updated `AGENTS.md` to require documentation for business logic or user-facing flow changes.

**Dependency management:**

* Added `browser-image-compression` and its dependency `uzip` to `frontend/package.json` and `frontend/package-lock.json`. [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655R26) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR17) [[3]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR2451-R2459) [[4]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR6542-R6547)

**Project hygiene:**

* Added `.codegraph/.gitignore` to prevent committing local data files generated by CodeGraph.