### PR TITLE
Add VITE_API_URL argument for Docker build stage

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,4 +1,5 @@
 ARG NODE_VERSION=22
+ARG VITE_API_URL
 
 FROM node:${NODE_VERSION}-alpine AS build
 WORKDIR /app
@@ -6,6 +7,10 @@ WORKDIR /app
 # Install dependencies using the lockfile for reproducible builds
 COPY frontend/package.json frontend/package-lock.json ./
 RUN npm ci --omit=dev
+
+# Re-declare ARG for stage scope; expose as ENV so Vite picks it up at build time
+ARG VITE_API_URL
+ENV VITE_API_URL=$VITE_API_URL
 
 # Copy application sources and produce the optimized build
 COPY frontend/ .


### PR DESCRIPTION
This pull request updates the `Dockerfile.frontend` to support passing a custom API URL to the frontend build process using the `VITE_API_URL` environment variable. This allows the Vite build to be configured dynamically at build time, making it easier to target different backend environments.

**Build configuration improvements:**

* Added a `VITE_API_URL` build argument to the Dockerfile, allowing the API URL to be set during the image build process.
* Exposed `VITE_API_URL` as an environment variable within the build stage so that Vite can access it when producing the optimized frontend build.