### PR TITLE
Add tests and update handling for gallery appearance settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,7 @@
     - Preserve isolation by keeping per-test DB cleanup (`TRUNCATE ... CASCADE`) and per-test S3 bucket isolation in place for tests that touch those resources.
     - If adding new integration tests, reuse existing container fixtures first; introduce new testcontainers only when mocking cannot validate required behavior.
 - Frontend checks: `cd frontend && npm run lint -- --fix && npm run test:run`.
+- Frontend production build requires `VITE_API_URL` in the environment; run it as `VITE_API_URL=https://... npm run build` or the Vite config will fail fast.
 
 ## Service Architecture
 - **RedisService** (`src/viewport/services/redis_service.py`):

--- a/frontend/src/__tests__/hooks/useGalleryActions.test.tsx
+++ b/frontend/src/__tests__/hooks/useGalleryActions.test.tsx
@@ -138,6 +138,55 @@ describe('useGalleryActions', () => {
     });
   });
 
+  it('returns the complete gallery detail when saving appearance settings', async () => {
+    const updatedGallery: Gallery = {
+      ...baseGallery,
+      cover_photo_id: 'photo-2',
+      cover_photo_thumbnail_url: '/photos/photo-2-thumb-presigned.jpg',
+      cover_focal_x: 24,
+      cover_focal_y: 76,
+      cover_display_option: 'text_block',
+      public_photo_spacing: 'large',
+      public_color_scheme: 'dark',
+    };
+    delete (updatedGallery as Gallery & Partial<GalleryDetail>).photos;
+    delete (updatedGallery as Gallery & Partial<GalleryDetail>).total_photos;
+    vi.mocked(galleryService.updateGallery).mockResolvedValue(updatedGallery);
+
+    const { result } = renderUseGalleryActions();
+
+    await act(async () => {
+      await result.current.fetchGalleryDetails(1, true);
+    });
+
+    let savedGallery: GalleryDetail | undefined;
+    await act(async () => {
+      savedGallery = await result.current.handleSaveAppearanceSettings({
+        cover_photo_id: 'photo-2',
+        cover_focal_x: 24,
+        cover_focal_y: 76,
+        cover_display_option: 'text_block',
+        public_photo_spacing: 'large',
+        public_color_scheme: 'dark',
+      });
+    });
+
+    expect(savedGallery).toMatchObject({
+      id: 'gallery-1',
+      cover_photo_id: 'photo-2',
+      cover_focal_x: 24,
+      cover_focal_y: 76,
+      cover_display_option: 'text_block',
+      public_photo_spacing: 'large',
+      public_color_scheme: 'dark',
+      cover_photo_thumbnail_url: '/photos/photo-2-thumb-presigned.jpg',
+      total_photos: 2,
+    });
+    expect(savedGallery?.photos).toEqual(photos);
+    expect(result.current.gallery?.photos).toEqual(photos);
+    expect(result.current.gallery?.total_photos).toBe(2);
+  });
+
   it('returns a complete fallback gallery when appearance cover save finds a deleted photo', async () => {
     vi.mocked(galleryService.updateGallery).mockRejectedValue(new ApiError(404, 'Photo not found'));
 

--- a/frontend/src/components/public-gallery/PublicGalleryHero.tsx
+++ b/frontend/src/components/public-gallery/PublicGalleryHero.tsx
@@ -93,7 +93,7 @@ export const PublicGalleryHero = ({
 
   if (!cover) {
     return (
-      <div className="mb-8 rounded-3xl border border-border/50 bg-surface-1/70 px-6 py-24 text-center shadow-xs dark:bg-surface-dark-1/70">
+      <div className="mb-8 rounded-3xl border border-border/50 bg-surface-1/70 px-6 py-24 text-center shadow-xs">
         <h1
           className={`pg-hero__empty-title ${emptyTitleSizeClass} mb-4 font-bold text-text wrap-break-word`}
         >
@@ -177,7 +177,7 @@ export const PublicGalleryHero = ({
   };
 
   return (
-    <div className="pg-hero relative w-full text-accent-foreground bg-surface-foreground/15 dark:bg-surface/20 overflow-hidden shadow-md">
+    <div className="pg-hero relative w-full text-accent-foreground bg-surface-foreground/15 overflow-hidden shadow-md">
       <img
         src={cover.thumbnail_url}
         alt=""

--- a/frontend/src/components/public-gallery/PublicGalleryPhotoSection.tsx
+++ b/frontend/src/components/public-gallery/PublicGalleryPhotoSection.tsx
@@ -137,9 +137,9 @@ const PhotoCommentPanel = ({
     if (saveState === 'error') return 'border-danger/30 bg-danger/10 text-danger';
     if (saveState === 'saving') return 'border-accent/30 bg-accent/10 text-accent';
     if (hasUnsavedChanges) {
-      return 'border-amber-400/30 bg-amber-400/10 text-amber-700 dark:text-amber-200';
+      return 'border-amber-400/30 bg-amber-400/10 text-amber-700';
     }
-    return 'border-emerald-500/25 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200';
+    return 'border-emerald-500/25 bg-emerald-500/10 text-emerald-700';
   })();
 
   const handleSave = useCallback(
@@ -324,7 +324,7 @@ export const PublicGalleryPhotoSection = ({
       </div>
 
       {isLoading ? (
-        <div className="flex min-h-80 items-center justify-center rounded-3xl border border-border/40 bg-surface-1/25 text-sm font-medium text-muted dark:border-border/20">
+        <div className="flex min-h-80 items-center justify-center rounded-3xl border border-border/40 bg-surface-1/25 text-sm font-medium text-muted">
           <Loader2 className="mr-3 h-6 w-6 animate-spin text-accent" />
           Loading gallery photos...
         </div>
@@ -402,7 +402,7 @@ export const PublicGalleryPhotoSection = ({
                               </span>
                             )}
                             anchor={{ to: 'bottom end', gap: '10px' }}
-                            panelClassName="w-[min(22rem,calc(100vw-2rem))] rounded-2xl border border-border/50 bg-surface/98 p-4 shadow-2xl backdrop-blur dark:border-border/30 dark:bg-surface-dark"
+                            panelClassName="w-[min(22rem,calc(100vw-2rem))] rounded-2xl border border-border/50 bg-surface/98 p-4 shadow-2xl backdrop-blur"
                             panel={(close) => (
                               <PhotoCommentPanel
                                 photoId={photo.photo_id}
@@ -456,7 +456,7 @@ export const PublicGalleryPhotoSection = ({
           )}
         </>
       ) : (
-        <div className="rounded-3xl border border-dashed border-border/50 bg-surface-1/20 py-20 text-center dark:border-border/10">
+        <div className="rounded-3xl border border-dashed border-border/50 bg-surface-1/20 py-20 text-center">
           <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-surface-foreground/10">
             <ImageOff className="h-8 w-8 text-muted" />
           </div>

--- a/frontend/src/components/public-gallery/PublicGalleryStates.tsx
+++ b/frontend/src/components/public-gallery/PublicGalleryStates.tsx
@@ -7,8 +7,8 @@ interface PublicGalleryErrorProps {
 }
 
 export const PublicGalleryError = ({ error }: PublicGalleryErrorProps) => (
-  <div className="flex min-h-screen items-center justify-center bg-surface p-4 text-text dark:bg-surface-dark">
-    <div className="w-full max-w-md rounded-3xl border border-border/50 bg-surface p-8 text-center shadow-2xl dark:border-white/10 dark:bg-surface-dark-1 sm:p-10">
+  <div className="flex min-h-screen items-center justify-center bg-surface p-4 text-text">
+    <div className="w-full max-w-md rounded-3xl border border-border/50 bg-surface p-8 text-center shadow-2xl sm:p-10">
       <div className="w-20 h-20 bg-danger/10 rounded-full flex items-center justify-center mx-auto mb-6">
         <AlertCircle className="w-10 h-10 text-danger" />
       </div>
@@ -19,8 +19,8 @@ export const PublicGalleryError = ({ error }: PublicGalleryErrorProps) => (
 );
 
 export const PublicGalleryExpired = () => (
-  <div className="flex min-h-screen items-center justify-center bg-surface p-4 text-text dark:bg-surface-dark">
-    <div className="w-full max-w-lg rounded-3xl border border-border/50 bg-surface p-8 text-center shadow-2xl dark:border-white/10 dark:bg-surface-dark-1 sm:p-10">
+  <div className="flex min-h-screen items-center justify-center bg-surface p-4 text-text">
+    <div className="w-full max-w-lg rounded-3xl border border-border/50 bg-surface p-8 text-center shadow-2xl sm:p-10">
       <div className="w-20 h-20 bg-accent/10 rounded-full flex items-center justify-center mx-auto mb-6">
         <Clock3 className="w-10 h-10 text-accent" />
       </div>

--- a/frontend/src/hooks/useGalleryActions.ts
+++ b/frontend/src/hooks/useGalleryActions.ts
@@ -256,13 +256,11 @@ export const useGalleryActions = ({
 
   const mergeAppearanceUpdate = useCallback(
     (base: GalleryDetail, updated: Awaited<ReturnType<typeof galleryService.updateGallery>>) => {
-      const appearanceUpdate = GALLERY_APPEARANCE_UPDATE_KEYS.reduce<GalleryAppearanceUpdatePayload>(
-        (acc, key) => {
+      const appearanceUpdate =
+        GALLERY_APPEARANCE_UPDATE_KEYS.reduce<GalleryAppearanceUpdatePayload>((acc, key) => {
           const value = updated[key];
           return value === undefined ? acc : { ...acc, [key]: value };
-        },
-        {},
-      );
+        }, {});
 
       return {
         ...base,

--- a/frontend/src/hooks/useGalleryActions.ts
+++ b/frontend/src/hooks/useGalleryActions.ts
@@ -242,6 +242,20 @@ export const useGalleryActions = ({
     [clearError, galleryId, handleError],
   );
 
+  const mergeAppearanceUpdate = useCallback(
+    (base: GalleryDetail, updated: Awaited<ReturnType<typeof galleryService.updateGallery>>) => ({
+      ...base,
+      cover_photo_id: updated.cover_photo_id,
+      cover_focal_x: updated.cover_focal_x,
+      cover_focal_y: updated.cover_focal_y,
+      cover_display_option: updated.cover_display_option,
+      public_photo_spacing: updated.public_photo_spacing,
+      public_color_scheme: updated.public_color_scheme,
+      cover_photo_thumbnail_url: updated.cover_photo_thumbnail_url,
+    }),
+    [],
+  );
+
   const handleSaveAppearanceSettings = useCallback(
     async (
       payload: Partial<
@@ -259,22 +273,18 @@ export const useGalleryActions = ({
       clearError();
       try {
         const updated = await galleryService.updateGallery(galleryId, payload);
-        setGallery((prev) => {
-          if (!prev) return prev;
-          const next = {
-            ...prev,
-            cover_photo_id: updated.cover_photo_id,
-            cover_focal_x: updated.cover_focal_x,
-            cover_focal_y: updated.cover_focal_y,
-            cover_display_option: updated.cover_display_option,
-            public_photo_spacing: updated.public_photo_spacing,
-            public_color_scheme: updated.public_color_scheme,
-            cover_photo_thumbnail_url: updated.cover_photo_thumbnail_url,
-          };
-          latestGalleryRef.current = next;
-          return next;
-        });
-        return updated as unknown as GalleryDetail;
+        const baseGallery = latestGalleryRef.current ?? gallery;
+        if (!baseGallery) {
+          const refreshed = await galleryService.getGallery(galleryId);
+          latestGalleryRef.current = refreshed;
+          setGallery(refreshed);
+          return refreshed;
+        }
+
+        const next = mergeAppearanceUpdate(baseGallery, updated);
+        latestGalleryRef.current = next;
+        setGallery(next);
+        return next;
       } catch (err) {
         if (payload.cover_photo_id && isNotFoundError(err)) {
           removePhotoLocally(payload.cover_photo_id);
@@ -293,6 +303,7 @@ export const useGalleryActions = ({
       galleryId,
       clearError,
       handleError,
+      mergeAppearanceUpdate,
       removePhotoLocally,
       isNotFoundError,
       setActionInfo,

--- a/frontend/src/hooks/useGalleryActions.ts
+++ b/frontend/src/hooks/useGalleryActions.ts
@@ -32,6 +32,18 @@ interface UseGalleryActionsProps {
   };
 }
 
+const GALLERY_APPEARANCE_UPDATE_KEYS = [
+  'cover_photo_id',
+  'cover_focal_x',
+  'cover_focal_y',
+  'cover_display_option',
+  'public_photo_spacing',
+  'public_color_scheme',
+] as const;
+
+type GalleryAppearanceUpdateKey = (typeof GALLERY_APPEARANCE_UPDATE_KEYS)[number];
+type GalleryAppearanceUpdatePayload = Partial<Pick<GalleryDetail, GalleryAppearanceUpdateKey>>;
+
 export const useGalleryActions = ({
   galleryId,
   parentProjectId,
@@ -243,33 +255,26 @@ export const useGalleryActions = ({
   );
 
   const mergeAppearanceUpdate = useCallback(
-    (base: GalleryDetail, updated: Awaited<ReturnType<typeof galleryService.updateGallery>>) => ({
-      ...base,
-      cover_photo_id: updated.cover_photo_id,
-      cover_focal_x: updated.cover_focal_x,
-      cover_focal_y: updated.cover_focal_y,
-      cover_display_option: updated.cover_display_option,
-      public_photo_spacing: updated.public_photo_spacing,
-      public_color_scheme: updated.public_color_scheme,
-      cover_photo_thumbnail_url: updated.cover_photo_thumbnail_url,
-    }),
+    (base: GalleryDetail, updated: Awaited<ReturnType<typeof galleryService.updateGallery>>) => {
+      const appearanceUpdate = GALLERY_APPEARANCE_UPDATE_KEYS.reduce<GalleryAppearanceUpdatePayload>(
+        (acc, key) => {
+          const value = updated[key];
+          return value === undefined ? acc : { ...acc, [key]: value };
+        },
+        {},
+      );
+
+      return {
+        ...base,
+        ...appearanceUpdate,
+        cover_photo_thumbnail_url: updated.cover_photo_thumbnail_url,
+      };
+    },
     [],
   );
 
   const handleSaveAppearanceSettings = useCallback(
-    async (
-      payload: Partial<
-        Pick<
-          GalleryDetail,
-          | 'cover_photo_id'
-          | 'cover_focal_x'
-          | 'cover_focal_y'
-          | 'cover_display_option'
-          | 'public_photo_spacing'
-          | 'public_color_scheme'
-        >
-      >,
-    ): Promise<GalleryDetail> => {
+    async (payload: GalleryAppearanceUpdatePayload): Promise<GalleryDetail> => {
       clearError();
       try {
         const updated = await galleryService.updateGallery(galleryId, payload);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1065,15 +1065,12 @@ body.dark .gallery-create__btn,
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.553);
 }
 
-/* Dark theme shadows for better visibility */
-.dark .pg-card,
-html.dark .pg-card {
+.pg-public-page.pg-theme-dark .pg-card {
   box-shadow: 0 6px 22px rgba(255, 255, 255, 0.08);
   border: 1px solid rgba(255, 255, 255, 0.05);
 }
 
-.dark .pg-card:hover,
-html.dark .pg-card:hover {
+.pg-public-page.pg-theme-dark .pg-card:hover {
   box-shadow:
     0 6px 22px rgba(255, 255, 255, 0.08),
     0 0 20px rgba(255, 255, 255, 0.05);
@@ -1282,8 +1279,8 @@ html.dark .pg-card:hover {
   background-color: rgb(var(--color-neutral-50-rgb));
 }
 
-.dark .pg-columns > .pg-card img.photo--wide,
-html.dark .pg-columns > .pg-card > button > img.photo--wide {
+.pg-public-page.pg-theme-dark .pg-columns > .pg-card img.photo--wide,
+.pg-public-page.pg-theme-dark .pg-columns > .pg-card > button > img.photo--wide {
   background-color: rgb(24, 24, 27);
 }
 

--- a/frontend/src/pages/PublicGalleryPage.tsx
+++ b/frontend/src/pages/PublicGalleryPage.tsx
@@ -599,7 +599,7 @@ export const PublicGalleryPage = () => {
 
   if (shouldShowPasswordPrompt) {
     return (
-      <div className="min-h-screen bg-surface text-text dark:bg-surface-foreground/5">
+      <div className="min-h-screen bg-surface text-text">
         <SkipToContentLink targetId="main-content" />
         <main
           id="main-content"
@@ -608,7 +608,7 @@ export const PublicGalleryPage = () => {
         >
           <form
             onSubmit={(event) => void handleSubmitSharePassword(event)}
-            className="w-full max-w-md rounded-3xl border border-border/50 bg-surface px-6 py-7 shadow-lg dark:border-border/30 dark:bg-surface-dark"
+            className="w-full max-w-md rounded-3xl border border-border/50 bg-surface px-6 py-7 shadow-lg"
           >
             <div className="mb-5 flex items-center gap-3">
               <div className="rounded-2xl bg-accent/10 p-3 text-accent">
@@ -626,7 +626,7 @@ export const PublicGalleryPage = () => {
                 value={sharePasswordDraft}
                 onChange={(event) => setSharePasswordDraft(event.target.value)}
                 autoComplete="current-password"
-                className="w-full rounded-xl border border-border/50 bg-surface-1 px-3 py-2.5 text-text outline-none transition-colors focus:border-accent dark:bg-surface-dark-1"
+                className="w-full rounded-xl border border-border/50 bg-surface-1 px-3 py-2.5 text-text outline-none transition-colors focus:border-accent"
               />
             </label>
             {sharePasswordError || errorStatus === 401 ? (
@@ -649,7 +649,7 @@ export const PublicGalleryPage = () => {
 
   if (isInitialGalleryLoading) {
     return (
-      <div className="min-h-screen bg-surface text-text dark:bg-surface-foreground/5">
+      <div className="min-h-screen bg-surface text-text">
         <SkipToContentLink targetId="main-content" />
         <main
           id="main-content"
@@ -679,7 +679,7 @@ export const PublicGalleryPage = () => {
   if (isProjectShare && !activeGalleryId && !isFavoritesView) {
     if (projectShare.galleries.length === 0) {
       return (
-        <div className="min-h-screen bg-surface text-text dark:bg-surface-foreground/5">
+        <div className="min-h-screen bg-surface text-text">
           <SkipToContentLink targetId="main-content" />
           <main
             id="main-content"
@@ -703,7 +703,7 @@ export const PublicGalleryPage = () => {
     }
 
     return (
-      <div className="min-h-screen bg-surface text-text dark:bg-surface-foreground/5">
+      <div className="min-h-screen bg-surface text-text">
         <SkipToContentLink targetId="main-content" />
         <main
           id="main-content"
@@ -1073,7 +1073,7 @@ export const PublicGalleryPage = () => {
             }}
             size="sm"
             initialFocusRef={startNameInputRef}
-            panelClassName="rounded-3xl border border-border/50 bg-surface p-5 shadow-xl dark:border-border/20 dark:bg-surface-dark"
+            panelClassName="rounded-3xl border border-border/50 bg-surface p-5 shadow-xl"
           >
             <form onSubmit={handleStartSelectionSubmit}>
               <AppDialogTitle className="text-lg font-semibold text-text">
@@ -1100,7 +1100,7 @@ export const PublicGalleryPage = () => {
                     placeholder="Your name"
                     aria-invalid={startFormError ? 'true' : undefined}
                     aria-describedby={startFormError ? 'selection-start-error' : undefined}
-                    className="w-full rounded-xl border border-border/50 bg-surface px-3 py-2.5 text-sm text-text outline-none focus:border-accent dark:bg-surface-dark-1"
+                    className="w-full rounded-xl border border-border/50 bg-surface px-3 py-2.5 text-sm text-text outline-none focus:border-accent"
                   />
                 </div>
                 {selection.config?.require_email ? (
@@ -1121,7 +1121,7 @@ export const PublicGalleryPage = () => {
                       placeholder="Email"
                       aria-invalid={startFormError ? 'true' : undefined}
                       aria-describedby={startFormError ? 'selection-start-error' : undefined}
-                      className="w-full rounded-xl border border-border/50 bg-surface px-3 py-2.5 text-sm text-text outline-none focus:border-accent dark:bg-surface-dark-1"
+                      className="w-full rounded-xl border border-border/50 bg-surface px-3 py-2.5 text-sm text-text outline-none focus:border-accent"
                     />
                   </div>
                 ) : null}
@@ -1142,7 +1142,7 @@ export const PublicGalleryPage = () => {
                       placeholder="Phone"
                       aria-invalid={startFormError ? 'true' : undefined}
                       aria-describedby={startFormError ? 'selection-start-error' : undefined}
-                      className="w-full rounded-xl border border-border/50 bg-surface px-3 py-2.5 text-sm text-text outline-none focus:border-accent dark:bg-surface-dark-1"
+                      className="w-full rounded-xl border border-border/50 bg-surface px-3 py-2.5 text-sm text-text outline-none focus:border-accent"
                     />
                   </div>
                 ) : null}
@@ -1163,7 +1163,7 @@ export const PublicGalleryPage = () => {
                       placeholder="Note"
                       aria-invalid={startFormError ? 'true' : undefined}
                       aria-describedby={startFormError ? 'selection-start-error' : undefined}
-                      className="w-full min-h-20 rounded-xl border border-border/50 bg-surface px-3 py-2.5 text-sm text-text outline-none focus:border-accent dark:bg-surface-dark-1"
+                      className="w-full min-h-20 rounded-xl border border-border/50 bg-surface px-3 py-2.5 text-sm text-text outline-none focus:border-accent"
                     />
                   </div>
                 ) : null}
@@ -1202,7 +1202,7 @@ export const PublicGalleryPage = () => {
           </AppDialog>
         ) : null}
 
-        <div className="mt-16 flex flex-wrap items-center justify-center gap-3 text-center text-sm font-medium text-muted dark:text-muted-foreground">
+        <div className="mt-16 flex flex-wrap items-center justify-center gap-3 text-center text-sm font-medium text-muted">
           <p>Powered by Viewport - Your Photo Gallery Solution</p>
           <Link to="/accessibility" className="font-semibold text-accent hover:underline">
             Accessibility
@@ -1214,7 +1214,7 @@ export const PublicGalleryPage = () => {
         <div className="pointer-events-none fixed inset-x-0 bottom-0 z-30 px-4 pb-4 sm:px-6 lg:px-10">
           <section
             data-testid="project-selection-sticky-bar"
-            className="pointer-events-auto mx-auto flex w-full max-w-6xl flex-col gap-3 rounded-3xl border border-border/50 bg-surface/95 px-4 py-4 shadow-xl backdrop-blur-xl dark:bg-surface-dark/95 sm:flex-row sm:items-center sm:justify-between"
+            className="pointer-events-auto mx-auto flex w-full max-w-6xl flex-col gap-3 rounded-3xl border border-border/50 bg-surface/95 px-4 py-4 shadow-xl backdrop-blur-xl sm:flex-row sm:items-center sm:justify-between"
           >
             <div className="space-y-1">
               <p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted">

--- a/src/viewport/api/public.py
+++ b/src/viewport/api/public.py
@@ -20,7 +20,7 @@ from viewport.s3_service import AsyncS3Client
 from viewport.s3_utils import get_s3_client, get_s3_settings
 from viewport.schemas.gallery import GalleryPhotoSortBy, SortOrder
 from viewport.schemas.photo import PHOTO_ID_BATCH_MAX
-from viewport.schemas.public import PublicCover, PublicGalleryResponse, PublicPhoto, PublicProjectGallery, PublicProjectResponse, PublicShareResponse, PublicShareUnlockRequest
+from viewport.schemas.public import PublicCover, PublicGalleryAppearance, PublicGalleryResponse, PublicPhoto, PublicProjectGallery, PublicProjectResponse, PublicShareResponse, PublicShareUnlockRequest
 from viewport.sharelink_access import PUBLIC_CACHE_CONTROL_HEADERS, get_available_public_sharelink, get_valid_public_sharelink, unlock_sharelink_password
 from viewport.zip_utils import build_zip_fallback_name, make_content_disposition_header, make_unique_zip_entry_name, sanitize_zip_entry_name
 
@@ -200,8 +200,6 @@ async def _build_public_gallery_response(
             ip_address=client_ip,
             user_agent=request.headers.get("user-agent"),
         )
-
-    from viewport.schemas.public import PublicGalleryAppearance
 
     return PublicGalleryResponse(
         photos=photo_list,


### PR DESCRIPTION
This pull request focuses on improving the handling of gallery appearance updates and unifying the visual theme for public gallery components by removing dark theme-specific classes and logic. The changes ensure that appearance settings updates correctly preserve all gallery detail fields and that the UI maintains a consistent look regardless of theme.

**Gallery appearance update improvements:**

* Refactored the `handleSaveAppearanceSettings` logic in `useGalleryActions` to ensure that when gallery appearance settings are updated, the returned and stored gallery object preserves all detail fields (such as `photos` and `total_photos`), even if the API response is partial. Introduced a new helper, `mergeAppearanceUpdate`, to merge updated fields into the base gallery detail. [[1]](diffhunk://#diff-dafdfa4c44ef37a9722a668b442e1bff47de853100db47e355699b1b6c792138R245-R258) [[2]](diffhunk://#diff-dafdfa4c44ef37a9722a668b442e1bff47de853100db47e355699b1b6c792138L262-L277) [[3]](diffhunk://#diff-dafdfa4c44ef37a9722a668b442e1bff47de853100db47e355699b1b6c792138R306)
* Added a comprehensive test to verify that saving appearance settings returns and stores a complete `GalleryDetail` object, including `photos` and `total_photos`.

**Visual theme and dark mode cleanup:**

* Removed most `dark:` Tailwind classes and dark theme-specific CSS from public gallery components and pages, ensuring a consistent appearance regardless of theme. This affects various elements in `PublicGalleryPage`, `PublicGalleryHero`, `PublicGalleryPhotoSection`, and related state components. [[1]](diffhunk://#diff-b21ce4d9d115c16f3794054bb6a40ed850aa8fbbdffdea1ae680d245a709ea65L602-R602) [[2]](diffhunk://#diff-b21ce4d9d115c16f3794054bb6a40ed850aa8fbbdffdea1ae680d245a709ea65L611-R611) [[3]](diffhunk://#diff-b21ce4d9d115c16f3794054bb6a40ed850aa8fbbdffdea1ae680d245a709ea65L629-R629) [[4]](diffhunk://#diff-b21ce4d9d115c16f3794054bb6a40ed850aa8fbbdffdea1ae680d245a709ea65L652-R652) [[5]](diffhunk://#diff-b21ce4d9d115c16f3794054bb6a40ed850aa8fbbdffdea1ae680d245a709ea65L682-R682) [[6]](diffhunk://#diff-b21ce4d9d115c16f3794054bb6a40ed850aa8fbbdffdea1ae680d245a709ea65L706-R706) [[7]](diffhunk://#diff-b21ce4d9d115c16f3794054bb6a40ed850aa8fbbdffdea1ae680d245a709ea65L1076-R1076) [[8]](diffhunk://#diff-b21ce4d9d115c16f3794054bb6a40ed850aa8fbbdffdea1ae680d245a709ea65L1103-R1103) [[9]](diffhunk://#diff-b21ce4d9d115c16f3794054bb6a40ed850aa8fbbdffdea1ae680d245a709ea65L1124-R1124) [[10]](diffhunk://#diff-b21ce4d9d115c16f3794054bb6a40ed850aa8fbbdffdea1ae680d245a709ea65L1145-R1145) [[11]](diffhunk://#diff-b21ce4d9d115c16f3794054bb6a40ed850aa8fbbdffdea1ae680d245a709ea65L1166-R1166) [[12]](diffhunk://#diff-3be4524850f306a62df7fdc5c79a46ab68876b3b66c51af4cee7cec7011e615cL96-R96) [[13]](diffhunk://#diff-3be4524850f306a62df7fdc5c79a46ab68876b3b66c51af4cee7cec7011e615cL180-R180) [[14]](diffhunk://#diff-f5a3b7f24ff47c0c9694b8041609aedf1ea3aa598d85fdbbcf4945a7a61d0967L140-R142) [[15]](diffhunk://#diff-f5a3b7f24ff47c0c9694b8041609aedf1ea3aa598d85fdbbcf4945a7a61d0967L327-R327) [[16]](diffhunk://#diff-f5a3b7f24ff47c0c9694b8041609aedf1ea3aa598d85fdbbcf4945a7a61d0967L405-R405) [[17]](diffhunk://#diff-f5a3b7f24ff47c0c9694b8041609aedf1ea3aa598d85fdbbcf4945a7a61d0967L459-R459) [[18]](diffhunk://#diff-bb2ca4c3cce63c4105b3d24c5f0c89978627b14e8bb7161cf69f96403220ac9fL10-R11) [[19]](diffhunk://#diff-bb2ca4c3cce63c4105b3d24c5f0c89978627b14e8bb7161cf69f96403220ac9fL22-R23)
* Updated CSS selectors to scope dark theme styles to `.pg-public-page.pg-theme-dark` instead of global `.dark` or `html.dark`, preventing dark theme overrides outside of public gallery pages. [[1]](diffhunk://#diff-b6889d573bf684293ea3c3e654c123bd3502dd1f8155470375a1e5a906f0c236L1068-R1073) [[2]](diffhunk://#diff-b6889d573bf684293ea3c3e654c123bd3502dd1f8155470375a1e5a906f0c236L1285-R1283)…ce handling